### PR TITLE
Issue #1291 - Suppress marking/feedback until after final attempt

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The following attributes are appended to a particular article within *articles.j
 
 >**_id** (string): This is a unique name for the assessment. This value is used by other plug-ins, such as [adapt-contrib-assessmentResults](https://github.com/adaptlearning/adapt-contrib-assessmentResults), to identify the assessment and to display its variables.
 
+>**_suppressMarking** (boolean): Suppresses the assessment question marking until completion of the assessment or until all attempts have been exhausted. Acceptable values are `true` or `false`.
+
 >**_isPercentageBased** (boolean): Determines whether the value of **_scoreToPass** should be treated as a percentage or as the raw score. For example, if **_isPercentageBased** is set to `true`, a **_scoreToPass** value of `60` will be treated as `60%`.   
 
 >**_scoreToPass** (number): This is the achievement score required to pass the assessment. The learner's score must be greater than or equal to this score. It is the cumulative raw score needed to pass unless **_isPercentageBased** is set to `true`.    

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-assessment",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "framework": "^2.0.0",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-assessment",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-assessment%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20screenshots.",

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-assessment",
   "version": "2.0.10",
-  "framework": "^2.0.15",
+  "framework": "^2.0.18",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-assessment",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-assessment%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20screenshots.",
   "displayName" : "Assessment",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-assessment",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "framework": "^2.0.15",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-assessment",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-assessment%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20screenshots.",

--- a/example.json
+++ b/example.json
@@ -17,6 +17,7 @@
             "_canShowMarking": false,
             "_canShowModelAnswer": false
         },
+        "_suppressMarking": false,
         "_isPercentageBased" : true,
         "_scoreToPass" : 75,
         "_includeInTotalScore": true,

--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -332,7 +332,7 @@ define([
 
             this._removeQuestionListeners();
 
-            if (this._isMarkingSuppressionEnabled() && this._isAttemptsEnabled() && !this._isAttemptsLeft()) {
+            if (this._isMarkingSuppressionEnabled() && !this._isAttemptsLeft()) {
                 _.defer(_.bind(function() {
                     this._overrideMarkingSettings();
                     this._refreshQuestions();
@@ -425,7 +425,7 @@ define([
         },
 
         _shouldSuppressMarking: function() {
-            return this._isMarkingSuppressionEnabled() && this._isAttemptsEnabled() && this._isAttemptsLeft();
+            return this._isMarkingSuppressionEnabled() && this._isAttemptsLeft();
         },
 
         _isMarkingSuppressionEnabled: function() {
@@ -433,13 +433,8 @@ define([
             return assessmentConfig._suppressMarking;
         },
 
-        _isAttemptsEnabled: function() {
-            var assessmentConfig = this.getConfig();
-            return assessmentConfig._attempts && assessmentConfig._attempts != "infinite";
-        },
-
         _isAttemptsLeft: function() {
-            if (!this._isAttemptsEnabled()) return true;
+            if (this.get('_isAssessmentComplete') && this.get('_isPass')) return false;
 
             if (this.get('_attemptsLeft') === 0) return false;
 

--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -236,7 +236,12 @@ define([
             this._overrideMarkingSettings();
 
             var newSettings = {};
+
             // Add any setting overrides here
+            var questionConfig = this.getConfig()._questions;
+            if (questionConfig.hasOwnProperty('_canShowFeedback')) {
+                newSettings._canShowFeedback = questionConfig._canShowFeedback;
+            }
 
             if (!_.isEmpty(newSettings)) {
                 for (var i = 0, l = this._currentQuestionComponents.length; i < l; i++) {
@@ -324,7 +329,7 @@ define([
 
             this._removeQuestionListeners();
 
-            if (this._isMarkingSuppressionEnabled() && this._isAttemptsEnabled() && this.get('_attemptsLeft') <= 0) {
+            if (this._isMarkingSuppressionEnabled() && this._isAttemptsEnabled() && !this._isAttemptsLeft()) {
                 this._overrideMarkingSettings();
                 this._refreshQuestions();
             }
@@ -389,7 +394,7 @@ define([
                 if (questionConfig.hasOwnProperty('_canShowFeedback')) {
                     markingSettings._canShowFeedback = questionConfig._canShowFeedback;
                 }
-                
+
                 if (questionConfig.hasOwnProperty('_canShowModelAnswer')) {
                     markingSettings._canShowModelAnswer = questionConfig._canShowModelAnswer;
                 }
@@ -403,7 +408,6 @@ define([
         },
 
         _overrideMarkingSettings: function() {
-            var questionConfig = this.getConfig()._questions;
             var newMarkingSettings = this._getMarkingSettings();
             for (var i = 0, l = this._currentQuestionComponents.length; i < l; i++) {
                 this._currentQuestionComponents[i].set(newMarkingSettings, {
@@ -411,14 +415,16 @@ define([
                 });
             }
         },
+
         _refreshQuestions: function() {
             for (var a = 0, b = this._currentQuestionComponents.length; a < b; a++) {
                 var question = this._currentQuestionComponents[a];
                 question.refresh();
             }
         },
+
         _shouldSuppressMarking: function() {
-            return this._isMarkingSuppressionEnabled() && this._isAttemptsEnabled() && this.get('_attemptsLeft') > 0;
+            return this._isMarkingSuppressionEnabled() && this._isAttemptsEnabled() && this._isAttemptsLeft();
         },
 
         _isMarkingSuppressionEnabled: function() {
@@ -521,8 +527,6 @@ define([
         _onRemove: function() {
             this._removeQuestionListeners();
         },
-
-
 
         _setCompletionStatus: function() {
             this.set({
@@ -672,7 +676,6 @@ define([
             this.set("_scoreAsPercent", scoreAsPercent);
             this.set("_lastAttemptScoreAsPercent", scoreAsPercent)
 
-
             var questions = [];
             for (var id in indexByIdQuestions) {
                 questions.push({
@@ -680,8 +683,6 @@ define([
                     _isCorrect: indexByIdQuestions[id]
                 });
             }
-
-
 
             this.set("_questions", questions);
             this._checkIsPass();

--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -249,9 +249,7 @@ define([
 
             if (!_.isEmpty(newSettings)) {
                 for (var i = 0, l = this._currentQuestionComponents.length; i < l; i++) {
-                    this._currentQuestionComponents[i].set(newSettings, {
-                        pluginName: "_assessment"
-                    });
+                    this._currentQuestionComponents[i].set(newSettings, { pluginName: "_assessment" });
                 }
             }
         },
@@ -334,8 +332,10 @@ define([
             this._removeQuestionListeners();
 
             if (this._isMarkingSuppressionEnabled() && this._isAttemptsEnabled() && !this._isAttemptsLeft()) {
-                this._overrideMarkingSettings();
-                this._refreshQuestions();
+                _.defer(_.bind(function() {
+                    this._overrideMarkingSettings();
+                    this._refreshQuestions();
+                }, this));
             }
 
             Adapt.trigger('assessments:complete', this.getState(), this);
@@ -383,7 +383,7 @@ define([
 
             this.set("_isPass", isPass);
         },
-
+        
         _getMarkingSettings: function() {
             var markingSettings = {};
 

--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -239,11 +239,9 @@ define([
         },
 
         _overrideQuestionComponentSettings: function() {
-            this._overrideMarkingSettings();
+            var newSettings = this._getMarkingSettings();
 
-            var newSettings = {};
-
-            // Add any setting overrides here
+            // Add any additional setting overrides here
             var questionConfig = this.getConfig()._questions;
             if (questionConfig.hasOwnProperty('_canShowFeedback')) {
                 newSettings._canShowFeedback = questionConfig._canShowFeedback;
@@ -392,14 +390,10 @@ define([
             if (this._shouldSuppressMarking()) {
                 markingSettings = {
                     _canShowMarking: false,
-                    _canShowModelAnswer: false,
-                    _canShowFeedback: false
+                    _canShowModelAnswer: false
                 };
             } else {
                 var questionConfig = this.getConfig()._questions;
-                if (questionConfig.hasOwnProperty('_canShowFeedback')) {
-                    markingSettings._canShowFeedback = questionConfig._canShowFeedback;
-                }
 
                 if (questionConfig.hasOwnProperty('_canShowModelAnswer')) {
                     markingSettings._canShowModelAnswer = questionConfig._canShowModelAnswer;

--- a/js/adapt-assessmentArticleView.js
+++ b/js/adapt-assessmentArticleView.js
@@ -11,7 +11,7 @@ define([
                 this._setupEventListeners();
 
                 var config = this.model.getConfig();
-                if (!config || !config._questions || !config._questions._canShowMarking || config._questions._suppressMarking) {
+                if (!config || !config._questions || !config._questions._canShowMarking || config._suppressMarking) {
                     this.$el.addClass('no-marking');
                 }
             }

--- a/js/adapt-assessmentArticleView.js
+++ b/js/adapt-assessmentArticleView.js
@@ -11,7 +11,7 @@ define([
                 this._setupEventListeners();
 
                 var config = this.model.getConfig();
-                if (!config || !config._questions || !config._questions._canShowMarking || config._suppressMarking) {
+                if (!config || !config._questions || !config._questions._canShowMarking || (config._suppressMarking && this.model._isAttemptsLeft())) {
                     this.$el.addClass('no-marking');
                 }
             }
@@ -34,7 +34,9 @@ define([
 
             var config = this.model.getConfig();
             if (config && config._questions && config._questions._canShowMarking) {
-                this.$el.removeClass('no-marking');
+                if (!(config._suppressMarking && this.model._isAttemptsLeft())) {
+                    this.$el.removeClass('no-marking');
+                }
             }
             
             console.log("assessment complete", state, model);

--- a/js/adapt-assessmentArticleView.js
+++ b/js/adapt-assessmentArticleView.js
@@ -11,7 +11,7 @@ define([
                 this._setupEventListeners();
 
                 var config = this.model.getConfig();
-                if (config && config._questions && config._questions._canShowMarking === false) {
+                if (!config || !config._questions || !config._questions._canShowMarking || config._questions._suppressMarking) {
                     this.$el.addClass('no-marking');
                 }
             }
@@ -32,8 +32,12 @@ define([
         _onAssessmentComplete: function(state, model) {
             if (state.id != this.model.get("_assessment")._id) return;
 
+            var config = this.model.getConfig();
+            if (config && config._questions && config._questions._canShowMarking) {
+                this.$el.removeClass('no-marking');
+            }
+            
             console.log("assessment complete", state, model);
-
         },
 
         _onAssessmentReset: function(state, model) {

--- a/js/adapt-assessmentArticleView.js
+++ b/js/adapt-assessmentArticleView.js
@@ -11,7 +11,7 @@ define([
                 this._setupEventListeners();
 
                 var config = this.model.getConfig();
-                if (!config || !config._questions || !config._questions._canShowMarking || (config._suppressMarking && this.model._isAttemptsLeft())) {
+                if (config && config._questions && config._questions._canShowMarking === false) {
                     this.$el.addClass('no-marking');
                 }
             }
@@ -32,13 +32,6 @@ define([
         _onAssessmentComplete: function(state, model) {
             if (state.id != this.model.get("_assessment")._id) return;
 
-            var config = this.model.getConfig();
-            if (config && config._questions && config._questions._canShowMarking) {
-                if (!(config._suppressMarking && this.model._isAttemptsLeft())) {
-                    this.$el.removeClass('no-marking');
-                }
-            }
-            
             console.log("assessment complete", state, model);
         },
 

--- a/properties.schema
+++ b/properties.schema
@@ -175,6 +175,7 @@
                   "required":false,
                   "title": "Suppress marking until assessment completion",
                   "inputType": { "type": "Boolean", "options": [false, true]},
+                  "default": true,
                   "validators": [],
                   "help": "If enabled, individual question marking will only occur when the user has completed the assessment. Dependant on Show Marking being enabled."
                 },

--- a/properties.schema
+++ b/properties.schema
@@ -161,6 +161,14 @@
                       "inputType": { "type": "Boolean", "options": [false, true]},
                       "validators": []
                     },
+                    "_suppressMarking": {
+                      "type":"boolean",
+                      "required":false,
+                      "title": "Suppress marking until assessment completion",
+                      "inputType": { "type": "Boolean", "options": [false, true]},
+                      "validators": [],
+                      "help": "If enabled, individual question marking will only occur when the user has completed the assessment. Dependant on Show Marking being enabled."
+                    },
                     "_canShowModelAnswer": {
                       "type":"boolean",
                       "required":false,

--- a/properties.schema
+++ b/properties.schema
@@ -215,7 +215,7 @@
                   "inputType": { "type": "Boolean", "options": [false, true]},
                   "default": true,
                   "validators": [],
-                  "help": "If enabled, individual question marking will only occur when the user has completed the assessment. Dependant on Show Marking being enabled."
+                  "help": "If enabled, individual question marking will only occur when the user has completed the assessment. Note: this is dependent on 'Show Marking' being enabled on the question component."
                 },
                 "_isPercentageBased": {
                   "type": "boolean",

--- a/properties.schema
+++ b/properties.schema
@@ -215,7 +215,7 @@
                   "inputType": { "type": "Boolean", "options": [false, true]},
                   "default": true,
                   "validators": [],
-                  "help": "If enabled, individual question marking will only occur when the user has completed the assessment. Note: this is dependent on 'Show Marking' being enabled on the question component."
+                  "help": "If enabled, individual question marking will only occur when the user has used up all assessment attempts or has passed the assessment. Note: this is dependent on 'Show Marking' being enabled on the question component."
                 },
                 "_isPercentageBased": {
                   "type": "boolean",

--- a/properties.schema
+++ b/properties.schema
@@ -161,14 +161,6 @@
                       "inputType": { "type": "Boolean", "options": [false, true]},
                       "validators": []
                     },
-                    "_suppressMarking": {
-                      "type":"boolean",
-                      "required":false,
-                      "title": "Suppress marking until assessment completion",
-                      "inputType": { "type": "Boolean", "options": [false, true]},
-                      "validators": [],
-                      "help": "If enabled, individual question marking will only occur when the user has completed the assessment. Dependant on Show Marking being enabled."
-                    },
                     "_canShowModelAnswer": {
                       "type":"boolean",
                       "required":false,
@@ -177,6 +169,14 @@
                       "validators": []
                     }
                   }
+                },
+                "_suppressMarking": {
+                  "type":"boolean",
+                  "required":false,
+                  "title": "Suppress marking until assessment completion",
+                  "inputType": { "type": "Boolean", "options": [false, true]},
+                  "validators": [],
+                  "help": "If enabled, individual question marking will only occur when the user has completed the assessment. Dependant on Show Marking being enabled."
                 },
                 "_isPercentageBased": {
                   "type":"boolean",


### PR DESCRIPTION
Related framework PR here:
https://github.com/adaptlearning/adapt_framework/pull/1360

Marking is suppressed for the duration of the assessment (on assessments with finite attempts only) by way of overriding the marking settings on the question components contained within it. Upon completion of the final attempt, marking is restored to the original settings and the question component views are refreshed to reflect their new states.
