### PR TITLE
Resolves issue with isPass

### DIFF
--- a/js/assessment.js
+++ b/js/assessment.js
@@ -294,7 +294,7 @@ define([
             var scoreAsPercent = Math.round((score / maxScore) * 100);
 
             if ((assessmentsConfig._scoreToPass || 100) && isComplete) {
-                if (assessmentsConfig._isPercentageBased || true) {
+                if (assessmentsConfig._isPercentageBased !== false) {
                     if (scoreAsPercent >= assessmentsConfig._scoreToPass) isPass = true;
                 } else {
                     if (score >= assessmentsConfig._scoreToPass) isPass = true;


### PR DESCRIPTION
Calculation on non-percentage based assessments was still comparing _scoreToPass (which could have been a number not a percentage) against the scoreAsPercent.

(Line 300 would never run.)