### PR TITLE
#1421 - Fixed completion of one assessment counting towards other assessments

### DIFF
--- a/js/assessment.js
+++ b/js/assessment.js
@@ -173,7 +173,7 @@ define([
                 for (var i = 0, l = assessments.length; i < l; i++) {
                     var assessmentState = assessments[i].getState();
 
-                    var isComplete;
+                    var isComplete = false;
 
                     if (requireAssessmentPassed) {
                         


### PR DESCRIPTION
Var hoisting was causing uncompleted assessments to be counted as completed when another assessment was completed.