### PR TITLE
Resolves #1621, inconsistencies in 'undefined' and empty _id values

### DIFF
--- a/js/assessment.js
+++ b/js/assessment.js
@@ -202,6 +202,22 @@ define([
             }
         },
 
+        _addToAssessmentIdMap: function(id, model) {
+            if (id === undefined) {
+                Adapt.log.warn("An assessment has been registered with an undefined value for '_id'");
+                return;
+            }
+
+            if (id === '') {
+                Adapt.log.warn("An assessment has been registered with an empty value for '_id'");
+            }
+
+            if (!this._assessments._byAssessmentId[id]) {
+                this._assessments._byAssessmentId[id] = model;
+            } else {
+                Adapt.log.warn("An assessment with an _id of '" + id + "' already exists!");
+            }
+        },
 
     //Public functions
 
@@ -216,19 +232,7 @@ define([
 
             this._assessments._byPageId[pageId].push(assessmentModel);
 
-            if (assessmentId !== undefined) {
-                if (assessmentId === '') {
-                    Adapt.log.warn("An assessment has been registered with an empty value for '_id'");
-                }
-
-                if (!this._assessments._byAssessmentId[assessmentId]) {
-                    this._assessments._byAssessmentId[assessmentId] = assessmentModel;
-                } else {
-                    Adapt.log.warn("An assessment with an '_id' of '" + assessmentId + "' already exists!");
-                }
-            } else {
-                Adapt.log.warn("An assessment has been registered with an undefined value for '_id'");
-            }
+            this._addToAssessmentIdMap(assessmentId, assessmentModel);
 
             this._assessments.push(assessmentModel);
 

--- a/js/assessment.js
+++ b/js/assessment.js
@@ -234,16 +234,16 @@ define([
 
             if (assessmentId !== undefined) {
                 if (assessmentId === '') {
-                    Adapt.log.warn("An assessment has been registered with an empty value for 'id'");
+                    Adapt.log.warn("An assessment has been registered with an empty value for '_id'");
                 }
 
                 if (!this._assessments._byAssessmentId[assessmentId]) {
                     this._assessments._byAssessmentId[assessmentId] = assessmentModel;
                 } else {
-                    Adapt.log.warn("An assessment with an id of '" + assessmentId + "' already exists!");
+                    Adapt.log.warn("An assessment with an '_id' of '" + assessmentId + "' already exists!");
                 }
             } else {
-                Adapt.log.warn("An assessment has been registered with an undefined value for 'id'");
+                Adapt.log.warn("An assessment has been registered with an undefined value for '_id'");
             }
 
             this._assessments.push(assessmentModel);

--- a/js/assessment.js
+++ b/js/assessment.js
@@ -37,7 +37,7 @@ define([
             if (assessmentId === undefined) return;
 
             if (!this._getStateByAssessmentId(assessmentId)) {
-                console.warn("assessments: state was not registered when assessment was created");
+                Adapt.log.warn("assessments: state was not registered when assessment was created");
             }
 
             this.saveState();
@@ -155,6 +155,10 @@ define([
         },
 
         _getStateByAssessmentId: function(assessmentId) {
+            if (assessmentId === undefined) {
+                return null;
+            }
+                
             return this._assessments._byAssessmentId[assessmentId].getState();
         },
 
@@ -225,10 +229,21 @@ define([
             if (this._assessments._byPageId[pageId] === undefined) {
                 this._assessments._byPageId[pageId] = [];
             }
+
             this._assessments._byPageId[pageId].push(assessmentModel);
 
-            if (assessmentId) {
-                this._assessments._byAssessmentId[assessmentId] = assessmentModel;
+            if (assessmentId !== undefined) {
+                if (assessmentId === '') {
+                    Adapt.log.warn("An assessment has been registered with an empty value for 'id'");
+                }
+
+                if (!this._assessments._byAssessmentId[assessmentId]) {
+                    this._assessments._byAssessmentId[assessmentId] = assessmentModel;
+                } else {
+                    Adapt.log.warn("An assessment with an id of '" + assessmentId + "' already exists!");
+                }
+            } else {
+                Adapt.log.warn("An assessment has been registered with an undefined value for 'id'");
             }
 
             this._assessments.push(assessmentModel);


### PR DESCRIPTION
Warning messages are now output when appropriate, but the code allows an empty assessment 'id', e.g. if there is only one assessment on the course.