### PR TITLE
add resetType to getState

### DIFF
--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -784,6 +784,7 @@ define([
                 attemptInProgress: this.get("_attemptInProgress"),
                 lastAttemptScoreAsPercent: this.get('_lastAttemptScoreAsPercent'),
                 questions: this.get("_questions"),
+                resetType: assessmentConfig._questions._resetType,
                 allowResetIfPassed: assessmentConfig._allowResetIfPassed,
                 questionModels: new Backbone.Collection(this._currentQuestionComponents)
             };


### PR DESCRIPTION
to allow other plugins to know what type of reset the assessment is doing

should help with https://github.com/adaptlearning/adapt_framework/issues/1933