### PR TITLE
fixes #1960 Allow assessment completion to be excluded from display

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 It is not a single [question component](https://github.com/adaptlearning/adapt_framework/wiki/Core-Plug-ins-in-the-Adapt-Learning-Framework#question-components). It is an extension that provides a score for all the [question components](https://github.com/adaptlearning/adapt_framework/wiki/Core-Plug-ins-in-the-Adapt-Learning-Framework#question-components) contained within a single [article](https://github.com/adaptlearning/adapt_framework/wiki/Framework-in-five-minutes#content-structure) and that communicates the score to the LMS if so configured. It does not display results. Results are presented with the [Assessment Results](https://github.com/adaptlearning/adapt-contrib-assessmentResults) component (for the results from a single assessment) or the [Assessment Results Total](https://github.com/adaptlearning/adapt-contrib-assessmentResultsTotal) component (for the results from multiple assessments).
 
 >**Important:**  
->The **Assessment** extension applies to the entire article. Since `_randomisation` may reorder blocks within the article, it is highly recommended to include only question components within the assessment article. 
-> 
+>The **Assessment** extension applies to the entire article. Since `_randomisation` may reorder blocks within the article, it is highly recommended to include only question components within the assessment article.
+>
 > **The Results component must be placed in a separate article, *not* within the assessment article.**
-> 
->Blocks inside an assessment article must contain a question. Any blocks containing only presentation components will not be rendered when the article is restored. 
+>
+>Blocks inside an assessment article must contain a question. Any blocks containing only presentation components will not be rendered when the article is restored.
 
 [Visit the **Assessment** wiki](https://github.com/adaptlearning/adapt-contrib-assessment/wiki) for explanations of key properties and for more information about its functionality such as [restoring state upon revisit](https://github.com/adaptlearning/adapt-contrib-assessment/wiki/Restore-assessment-state).
 
@@ -52,7 +52,7 @@ The following attributes, set within *course.json*, configure the defaults for a
 #### *articles.json*  
 The following attributes are appended to a particular article within *articles.json*. Multiple assessments may be used within a course, but they must be configured in separate articles.
 
-**_assessment** (object): The Assessment object that contains values for **_isEnabled**, **_id**, **_isPercentageBased**, **_scoreToPass**, **_banks**, **_randomisation**,  **_questions**, **_includeInTotalScore**, **_assessmentWeight**, **_isResetOnRevisit**, and **_attempts**.  
+**_assessment** (object): The Assessment object that contains values for **_isEnabled**, **_id**, **_isPercentageBased**, **_scoreToPass**, **_banks**, **_randomisation**,  **_questions**, **_includeInTotalScore**, **_includeInPageProgress**, **_assessmentWeight**, **_isResetOnRevisit**, and **_attempts**.  
 
 >**_isEnabled** (boolean): Turns the assessment on or off. Acceptable values are `true` or `false`.
 
@@ -65,6 +65,8 @@ The following attributes are appended to a particular article within *articles.j
 >**_scoreToPass** (number): This is the achievement score required to pass the assessment. The learner's score must be greater than or equal to this score. It is the cumulative raw score needed to pass unless **_isPercentageBased** is set to `true`.    
 
 >**_includeInTotalScore** (boolean): Determines if the score from this assessment should be sent to the LMS. The score sent is a percentage according to _assessmentWeight.   
+
+>**_includeInPageProgress** (boolean): Determines if the passed/failed status from this assessment should be in the page progress display.    
 
 >**_banks** (object): If **_banks** is enabled, its attributes determine which questions from a series of question banks/buckets will be presented to the learner. Contains values for **_isEnabled**, **_split**, and **_randomisation**.   (Use either **_banks** or **_randomisation**; the value of their **_isEnabled** attributes must be opposite booleans. If **_banks** is enabled, blocks must be organized into questions banks by adding the **_quizBankID** attribute referenced below.)
 
@@ -168,9 +170,9 @@ If data is required to be passed to a SCORM conformant LMS, the [Spoor](https://
 **Important:** if targetting IE8, it is recommended to limit each assessment to a maximum of 12 questions. When using question banks, the recommendation is a limit of 32 questions with a maximum of 12 questions drawn. These limits are recommended to help avoid the popup warning "A script on this page is causing Internet Explorer to run slowly". See https://support.microsoft.com/en-gb/kb/175500 for more information.
 
 ----------------------------
-**Version number:**  2.2.0   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
+**Version number:**  2.2.0   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>
 **Framework versions:** 2.2+
-**Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-assessment/graphs/contributors) 
-**Accessibility support:** WAI AA 
-**RTL support:** yes 
-**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, IE10, IE9, IE8, IE Mobile 11, Safari 10+11 for macOS+iOS, Opera 
+**Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-assessment/graphs/contributors)
+**Accessibility support:** WAI AA
+**RTL support:** yes
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, IE10, IE9, IE8, IE Mobile 11, Safari 10+11 for macOS+iOS, Opera

--- a/example.json
+++ b/example.json
@@ -21,6 +21,7 @@
         "_isPercentageBased" : true,
         "_scoreToPass" : 75,
         "_includeInTotalScore": true,
+        "_includeInPageProgress": true,
         "_assessmentWeight": 1,
         "_isResetOnRevisit": false,
         "_allowResetIfPassed": false,

--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -17,6 +17,7 @@ define([
         "_isPercentageBased" : true,
         "_scoreToPass" : 100,
         "_includeInTotalScore": true,
+        "_includeInPageProgress": true,
         "_assessmentWeight": 1,
         "_isResetOnRevisit": true,
         "_reloadPageOnReset": true,
@@ -111,7 +112,7 @@ define([
             if (shouldResetAssessment || shouldResetQuestions) {
                 Adapt.trigger('assessments:preReset', this.getState(), this);
             }
-            
+
             var quizModels;
             if (shouldResetAssessment) {
                 this.set("_numberOfQuestionsAnswered", 0);
@@ -163,7 +164,7 @@ define([
                 if (!state.isComplete) {
                     this.set("_attemptInProgress", true);
                 }
-                
+
                 this._overrideQuestionComponentSettings();
                 this._setupQuestionListeners();
                 this._checkNumberOfQuestionsAnswered();
@@ -172,7 +173,7 @@ define([
                 Adapt.assessment.saveState();
 
                 if (typeof callback == 'function') callback.apply(this);
-                
+
                 if (shouldResetAssessment || shouldResetQuestions) {
                     Adapt.trigger('assessments:postReset', this.getState(), this);
                 }
@@ -213,8 +214,8 @@ define([
             for (var i = 0, l = banks.length; i < l; i++) {
                 var bank = banks[i];
                 bankId = (i+1);
-                var questionBank = new QuestionBank(bankId, 
-                                                this.get("_id"), 
+                var questionBank = new QuestionBank(bankId,
+                                                this.get("_id"),
                                                 bank,
                                                 true);
 
@@ -243,7 +244,7 @@ define([
             if (randomisationModel._blockCount > 0) {
                 questionModels = questionModels.slice(0, randomisationModel._blockCount);
             }
-            
+
             return questionModels;
         },
 
@@ -385,7 +386,7 @@ define([
 
             this.set("_isPass", isPass);
         },
-        
+
         _getMarkingSettings: function() {
             var markingSettings = {};
 
@@ -583,9 +584,9 @@ define([
         },
 
         reset: function(force, callback) {
-            
+
             if (this._isResetInProgress) {
-                // prevent multiple resets from executing. 
+                // prevent multiple resets from executing.
                 // keep callbacks in queue for when current reset is finished
                 this.once("reset", function() {
                     this._isResetInProgress = false;
@@ -595,7 +596,7 @@ define([
                 });
                 return;
             }
-            
+
             var assessmentConfig = this.getConfig();
 
             //check if forcing reset via page revisit or force parameter
@@ -605,16 +606,16 @@ define([
             var isPageReload = this._checkReloadPage();
 
             //stop resetting if not complete or not allowed
-            if (this.get("_assessmentCompleteInSession") && 
-                    !assessmentConfig._isResetOnRevisit && 
-                    !isPageReload && 
+            if (this.get("_assessmentCompleteInSession") &&
+                    !assessmentConfig._isResetOnRevisit &&
+                    !isPageReload &&
                     !force) {
                 if (typeof callback == 'function') {
                     callback(false);
                 }
                 return false;
             }
-            
+
             //check if new session and questions not restored
             var wereQuestionsRestored = this._checkIfQuestionsWereRestored();
             force = force || wereQuestionsRestored;
@@ -624,7 +625,7 @@ define([
                 this.set({'_attemptsLeft':this.get('_attempts')});
                 this.set({'_attemptsSpent':0});
             }
-            
+
             var allowResetIfPassed = this.get('_assessment')._allowResetIfPassed;
             //stop resetting if no attempts left and allowResetIfPassed is false
             if (!this._isAttemptsLeft() && !force && !allowResetIfPassed) {
@@ -672,7 +673,7 @@ define([
                     };
 
                     indexByIdQuestions.push(componentModel);
-                    
+
                 });
 
                 indexByIdQuestions = _.indexBy(indexByIdQuestions, "_id");
@@ -754,7 +755,7 @@ define([
             this.set("_questions", questions);
 
             this._checkIsPass();
-            
+
             Adapt.trigger("assessments:restored", this.getState(), this);
         },
 
@@ -777,6 +778,7 @@ define([
                 maxScore: this.get("_maxScore"),
                 isPass: this.get("_isPass"),
                 includeInTotalScore: assessmentConfig._includeInTotalScore,
+                includeInPageProgress: assessmentConfig._includeInPageProgress,
                 assessmentWeight: assessmentConfig._assessmentWeight,
                 attempts: this.get("_attempts"),
                 attemptsSpent: this.get("_attemptsSpent"),

--- a/js/assessment.js
+++ b/js/assessment.js
@@ -92,8 +92,8 @@ define([
         },
 
         _checkResetAssessmentsOnRevisit: function(toObject) {
-            /* 
-                Here we hijack router:location to reorganise the assessment blocks 
+            /*
+                Here we hijack router:location to reorganise the assessment blocks
                 this must happen before trickle listens to block completion
             */
             if (toObject._contentType !== "page") return;
@@ -165,11 +165,11 @@ define([
             });
             Adapt.course.set("_assessment", assessmentsConfig);
         },
-        
+
         _postScoreToLms: function() {
             var assessmentsConfig = this.getConfig();
             if (assessmentsConfig._postTotalScoreToLms === false) return;
-            
+
             var completionState = this.getState();
             //post completion to spoor
             _.defer(function() {
@@ -185,7 +185,7 @@ define([
             if (assessmentId === undefined) {
                 return null;
             }
-                
+
             return this._assessments._byAssessmentId[assessmentId].getState();
         },
 
@@ -201,7 +201,7 @@ define([
 
         _setPageProgress: function() {
             //set _subProgressTotal and _subProgressComplete on pages that have assessment progress indicator requirements
-            
+
             for (var k in this._assessments._byPageId) {
 
                 var assessments = this._assessments._byPageId[k];
@@ -212,10 +212,10 @@ define([
                 for (var i = 0, l = assessments.length; i < l; i++) {
                     var assessmentState = assessments[i].getState();
 
-                    if (assessmentState.includeInTotalScore && !assessmentState.isPass) continue;
+                    if (assessmentState.includeInPageProgress && assessmentState.includeInTotalScore && !assessmentState.isPass) continue;
 
                     if (assessmentState.isComplete) {
-                        assessmentsPassed++; 
+                        assessmentsPassed++;
                     }
                 }
 
@@ -307,7 +307,7 @@ define([
 
             return assessmentsConfig;
         },
-        
+
         getState: function() {
             var assessmentsConfig = this.getConfig();
 
@@ -330,7 +330,7 @@ define([
             }
 
             var isComplete = assessmentsComplete == totalAssessments;
-            
+
             var scoreAsPercent = Math.round((score / maxScore) * 100);
 
             if ((assessmentsConfig._scoreToPass || 100) && isComplete) {

--- a/properties.schema
+++ b/properties.schema
@@ -111,6 +111,14 @@
                   "help": "Determines if the score from this assessment should be sent to the LMS. The score sent is a percentage according to 'Assessment Weight'.",
                   "validators": []
                 },
+                "_includeInPageProgress": {
+                  "type": "boolean",
+                  "default": true,
+                  "title": "Include in Page Progress",
+                  "inputType": "Checkbox",
+                  "help": "Determines if the result from this assessment should be included in any progress display.",
+                  "validators": []
+                },
                 "_assessmentWeight": {
                   "type": "number",
                   "required": false,


### PR DESCRIPTION
Minimal change to allow control of how the assessment is included in _subProgressComplete.

Hopefully the intention is clearer. Assessments without _includeInPageProgress default to include pass/fail status in the completion calculation.

