### PR TITLE
Adding option to not reset assessment in stateful systems if it is fa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The following attributes, set within *course.json*, configure the defaults for a
 #### *articles.json*  
 The following attributes are appended to a particular article within *articles.json*. Multiple assessments may be used within a course, but they must be configured in separate articles.
 
-**_assessment** (object): The Assessment object that contains values for **_isEnabled**, **_id**, **_isPercentageBased**, **_scoreToPass**, **_banks**, **_randomisation**,  **_questions**, **_includeInTotalScore**, **_assessmentWeight**, **_isResetOnRevisit**, and **_attempts**.  
+**_assessment** (object): The Assessment object that contains values for **_isEnabled**, **_id**, **_isPercentageBased**, **_scoreToPass**, **_banks**, **_randomisation**,  **_questions**, **_includeInTotalScore**, **_assessmentWeight**, **_isResetOnRevisit**, **_isResetIfFailed** and **_attempts**.  
 
 >**_isEnabled** (boolean): Turns the assessment on or off. Acceptable values are `true` or `false`.
 
@@ -92,7 +92,9 @@ The following attributes are appended to a particular article within *articles.j
 
 >**_assessmentWeight** (number): If there are multiple assessments in the course, this value controls the proportion of the LMS score which is attributed to this assessment. 1 = 100%.    
 
->**_isResetOnRevisit** (boolean): Controls whether the assessment should be reset automatically (up to the number of available attempts) when a user revisits the page. Acceptable values are `true` or `false`.   
+>**_isResetOnRevisit** (boolean): Controls whether the assessment should be reset automatically (up to the number of available attempts) when a user revisits the page. Acceptable values are `true` or `false`.
+
+>**_isResetIfFailed** (boolean): Controls whether the assessment should be reset automatically (up to the number of available attempts) if a previous attempt (in a previous session) has failed. Acceptable values are `true` or `false`. Note: This is only applicable in stateful systems.
 
 >**_attempts** (number): Controls the number of attempts available to the user. Any of the following values may be used to indicate an infinite number of attempts: `-1`, `0`, `null`, `undefined`, `"infinite"`.  
 

--- a/example.json
+++ b/example.json
@@ -22,7 +22,7 @@
         "_scoreToPass" : 75,
         "_includeInTotalScore": true,
         "_assessmentWeight": 1,
-        "_isResetOnRevisit": false,
+        "_isResetOnRevisit": true,
         "_isResetIfFailed": true,
         "_allowResetIfPassed": false,
         "_attempts": 2

--- a/example.json
+++ b/example.json
@@ -23,6 +23,7 @@
         "_includeInTotalScore": true,
         "_assessmentWeight": 1,
         "_isResetOnRevisit": false,
+        "_isResetIfFailed": true,
         "_allowResetIfPassed": false,
         "_attempts": 2
     }

--- a/example.json
+++ b/example.json
@@ -22,7 +22,7 @@
         "_scoreToPass" : 75,
         "_includeInTotalScore": true,
         "_assessmentWeight": 1,
-        "_isResetOnRevisit": true,
+        "_isResetOnRevisit": false,
         "_isResetIfFailed": true,
         "_allowResetIfPassed": false,
         "_attempts": 2

--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -19,6 +19,7 @@ define([
         "_includeInTotalScore": true,
         "_assessmentWeight": 1,
         "_isResetOnRevisit": true,
+        "_isResetIfFailed": true,
         "_reloadPageOnReset": true,
         "_attempts": "infinite",
         "_allowResetIfPassed": false
@@ -105,8 +106,9 @@ define([
         _setupAssessmentData: function(force, callback) {
             var assessmentConfig = this.getConfig();
             var state = this.getState();
-            var shouldResetAssessment = (!this.get("_attemptInProgress") && !state.isPass) || force === true;
-            var shouldResetQuestions = (assessmentConfig._isResetOnRevisit && (state.allowResetIfPassed || !state.isPass)) || force === true;
+
+            var shouldResetAssessment = (!this.get("_attemptInProgress") && (assessmentConfig._isResetIfFailed && !state.isPass)) || force === true;
+            var shouldResetQuestions = (assessmentConfig._isResetOnRevisit && (assessmentConfig._isResetIfFailed && (state.allowResetIfPassed || !state.isPass))) || force === true;
 
             if (shouldResetAssessment || shouldResetQuestions) {
                 Adapt.trigger('assessments:preReset', this.getState(), this);
@@ -785,7 +787,6 @@ define([
                 attemptInProgress: this.get("_attemptInProgress"),
                 lastAttemptScoreAsPercent: this.get('_lastAttemptScoreAsPercent'),
                 questions: this.get("_questions"),
-                resetType: assessmentConfig._questions._resetType,
                 allowResetIfPassed: assessmentConfig._allowResetIfPassed,
                 questionModels: new Backbone.Collection(this._currentQuestionComponents)
             };

--- a/properties.schema
+++ b/properties.schema
@@ -137,6 +137,15 @@
                   "help": "Controls whether the assessment should be reset automatically (up to the number of available attempts) when a user revisits the page.",
                   "validators": []
                 },
+                "_isResetIfFailed": {
+                  "type": "boolean",
+                  "required": true,
+                  "default": false,
+                  "title": "Reset if Failed",
+                  "inputType": "Checkbox",
+                  "help": "Controls whether the assessment should be reset automatically (up to the number of available attempts) if a previous attempt (in a previous session) has failed. Note: This is only applicable in stateful systems.",
+                  "validators": []
+                },
                 "_allowResetIfPassed": {
                   "type": "boolean",
                   "required": true,

--- a/properties.schema
+++ b/properties.schema
@@ -131,7 +131,7 @@
                 "_isResetOnRevisit": {
                   "type": "boolean",
                   "required": true,
-                  "default": false,
+                  "default": true,
                   "title": "Reset on Revisit",
                   "inputType": "Checkbox",
                   "help": "Controls whether the assessment should be reset automatically (up to the number of available attempts) when a user revisits the page.",

--- a/properties.schema
+++ b/properties.schema
@@ -131,7 +131,7 @@
                 "_isResetOnRevisit": {
                   "type": "boolean",
                   "required": true,
-                  "default": true,
+                  "default": false,
                   "title": "Reset on Revisit",
                   "inputType": "Checkbox",
                   "help": "Controls whether the assessment should be reset automatically (up to the number of available attempts) when a user revisits the page.",
@@ -140,7 +140,7 @@
                 "_isResetIfFailed": {
                   "type": "boolean",
                   "required": true,
-                  "default": false,
+                  "default": true,
                   "title": "Reset if Failed",
                   "inputType": "Checkbox",
                   "help": "Controls whether the assessment should be reset automatically (up to the number of available attempts) if a previous attempt (in a previous session) has failed. Note: This is only applicable in stateful systems.",


### PR DESCRIPTION
Adding option to not reset assessment in stateful systems if it is failed.

This brings the behaviour in line with passed and partially complete assessments.

Fixes adaptlearning/adapt_framework#2173