### PR TITLE
Fixes #2294, reset() respects the 'force' flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ If data is required to be passed to a SCORM conformant LMS, the [Spoor](https://
 **Important:** if targetting IE8, it is recommended to limit each assessment to a maximum of 12 questions. When using question banks, the recommendation is a limit of 32 questions with a maximum of 12 questions drawn. These limits are recommended to help avoid the popup warning "A script on this page is causing Internet Explorer to run slowly". See https://support.microsoft.com/en-gb/kb/175500 for more information.
 
 ----------------------------
-**Version number:**  2.3.0   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
+**Version number:**  2.3.1   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
 **Framework versions:** 3.2+  
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-assessment/graphs/contributors)  
 **Accessibility support:** WAI AA  

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-assessment",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "framework": ">=3.2",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-assessment",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",

--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -613,7 +613,7 @@ define([
             force = force || wereQuestionsRestored;
             // the assessment is going to be reset so we must reset attempts
             // otherwise assessment may not be set up properly in next session
-            if (wereQuestionsRestored && !this._isAttemptsLeft()) {
+            if (force && !this._isAttemptsLeft()) {
                 this.set({
                     _attemptsLeft: this.get('_attempts'),
                     _attemptsSpent: 0


### PR DESCRIPTION
If _checkIfQuestionsWereRestored() ever returned false/undefined, which
it would if _assessmentCompleteInSession was false, this could never reset properly.