### PR TITLE
Resolves #2398, adds a new 'assessment:restored' event

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ If data is required to be passed to a SCORM conformant LMS, the [Spoor](https://
 **Important:** if targetting IE8, it is recommended to limit each assessment to a maximum of 12 questions. When using question banks, the recommendation is a limit of 32 questions with a maximum of 12 questions drawn. These limits are recommended to help avoid the popup warning "A script on this page is causing Internet Explorer to run slowly". See https://support.microsoft.com/en-gb/kb/175500 for more information.
 
 ----------------------------
-**Version number:**  3.0.2   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
+**Version number:**  3.1.0   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
 **Framework versions:** 3.2+  
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-assessment/graphs/contributors)  
 **Accessibility support:** WAI AA  

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ If data is required to be passed to a SCORM conformant LMS, the [Spoor](https://
 **Important:** if targetting IE8, it is recommended to limit each assessment to a maximum of 12 questions. When using question banks, the recommendation is a limit of 32 questions with a maximum of 12 questions drawn. These limits are recommended to help avoid the popup warning "A script on this page is causing Internet Explorer to run slowly". See https://support.microsoft.com/en-gb/kb/175500 for more information.
 
 ----------------------------
-**Version number:**  3.0.1   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
+**Version number:**  3.0.2   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
 **Framework versions:** 3.2+  
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-assessment/graphs/contributors)  
 **Accessibility support:** WAI AA  

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-assessment",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "framework": ">=3.2",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-assessment",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-assessment",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "framework": ">=3.2",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-assessment",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",

--- a/js/assessment.js
+++ b/js/assessment.js
@@ -136,6 +136,8 @@ define([
                 _byPageId: {},
                 _byAssessmentId: {}
             });
+
+            this._restoredCount = 0;
         },
 
         _checkAssessmentsComplete: function() {
@@ -291,12 +293,19 @@ define([
             this._assessments.push(assessmentModel);
 
             this._restoreModelState(assessmentModel);
+            this._restoredCount++;
 
             Adapt.trigger('assessments:register', state, assessmentModel);
 
             this._setPageProgress();
 
             this._setupQuestionNumbering();
+
+            if (this._restoredCount === this._assessments.length) {
+                // Since all assessments have been stored, broadcast an
+                // event which has the collated state.
+                Adapt.trigger('assessment:restored', this.getState());
+            }
         },
 
         get: function(id) {


### PR DESCRIPTION
This event passes the collated assessment state and is a pre-requisite for
restoring the assessment state in the framework tracking.js module.