### PR TITLE
issue/3163 Added correctToPass and _hasItemScoring support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The following attributes, set within *course.json*, configure the defaults for a
 
 >**\_correctToPass** (integer): This is the achievement correctness required to pass the assessment. The learner's score must be greater than or equal to this score. It is the cumulative raw correctness needed to pass unless **\_isPercentageBased** is set to `true`.  
 
->**\_isPercentageBased** (boolean): Determines whether the value of **\_scoreToPass** should be treated as a percentage or as the raw score. For example, if **\_isPercentageBased** is set to `true`, a **\_scoreToPass** value of `60` will be treated as `60%`.  
+>**\_isPercentageBased** (boolean): Determines whether the values of **\_scoreToPass** and **\_correctToPass** should be treated as a percentage or as the raw score and correctness. For example, if **\_isPercentageBased** is set to `true`, a **\_scoreToPass** value of `60` will be treated as `60%`.  
 
 <div float align=right><a href="#top">Back to Top</a></div>
 
@@ -64,7 +64,7 @@ The following attributes are appended to a particular article within *articles.j
 
 >**\_correctToPass** (number): This is the achievement correctness required to pass the assessment. The learner's correctness must be greater than or equal to this value. It is the cumulative raw correctness needed to pass unless **\_isPercentageBased** is set to `true`.    
 
->**\_isPercentageBased** (boolean): Determines whether the value of **\_scoreToPass** should be treated as a percentage or as the raw score. For example, if **\_isPercentageBased** is set to `true`, a **\_scoreToPass** value of `60` will be treated as `60%`.   
+>**\_isPercentageBased** (boolean): Determines whether the valuex of **\_scoreToPass** and **\_correctToPass** should be treated as a percentage or as the raw score and correctness. For example, if **\_isPercentageBased** is set to `true`, a **\_scoreToPass** value of `60` will be treated as `60%`.   
 
 >**\_includeInTotalScore** (boolean): Determines if the score from this assessment should be sent to the LMS. The score sent is a percentage according to **\_assessmentWeight.**   
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The following attributes, set within *course.json*, configure the defaults for a
 
 >**\_correctToPass** (integer): This is the achievement correctness required to pass the assessment. The learner's score must be greater than or equal to this score. It is the cumulative raw correctness needed to pass unless **\_isPercentageBased** is set to `true`.  
 
->**\_isPercentageBased** (boolean): Determines whether the values of **\_scoreToPass** and **\_correctToPass** should be treated as a percentage or as the raw score and correctness. For example, if **\_isPercentageBased** is set to `true`, a **\_scoreToPass** value of `60` will be treated as `60%`.  
+>**\_isPercentageBased** (boolean): Determines whether the values of **\_scoreToPass** and **\_correctToPass** should be treated as percentages or as the raw score and correctness. For example, if **\_isPercentageBased** is set to `true`, a **\_scoreToPass** value of `60` will be treated as `60%`.  
 
 <div float align=right><a href="#top">Back to Top</a></div>
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,13 @@ With the [Adapt CLI](https://github.com/adaptlearning/adapt-cli) installed, run 
 #### *course.json*  
 The following attributes, set within *course.json*, configure the defaults for all assessments in the course. These attributes can be overridden on a per assessment basis by setting attributes of the same names in *articles.json*.
 
-**\_assessment** (object): The Assessment object that contains values for **\_scoreToPass** and **\_isPercentageBased**.
+**\_assessment** (object): The Assessment object that contains values for **\_scoreToPass** and **\_isPercentageBased**.  
 
->**\_scoreToPass** (integer): This is the achievement score required to pass the assessment. The learner's score must be greater than or equal to this score. It is the cumulative raw score needed to pass unless **\_isPercentageBased** is set to `true`.
+>**\_scoreToPass** (integer): This is the achievement score required to pass the assessment. The learner's score must be greater than or equal to this score. It is the cumulative raw score needed to pass unless **\_isPercentageBased** is set to `true`.  
 
->**\_isPercentageBased** (boolean): Determines whether the value of **\_scoreToPass** should be treated as a percentage or as the raw score. For example, if **\_isPercentageBased** is set to `true`, a **\_scoreToPass** value of `60` will be treated as `60%`.
+>**\_correctToPass** (integer): This is the achievement correctness required to pass the assessment. The learner's score must be greater than or equal to this score. It is the cumulative raw correctness needed to pass unless **\_isPercentageBased** is set to `true`.  
+
+>**\_isPercentageBased** (boolean): Determines whether the value of **\_scoreToPass** should be treated as a percentage or as the raw score. For example, if **\_isPercentageBased** is set to `true`, a **\_scoreToPass** value of `60` will be treated as `60%`.  
 
 <div float align=right><a href="#top">Back to Top</a></div>
 
@@ -59,6 +61,8 @@ The following attributes are appended to a particular article within *articles.j
 >**\_suppressMarking** (boolean): Suppresses the assessment question marking until completion of the assessment or until all attempts have been exhausted. Acceptable values are `true` or `false`.
 
 >**\_scoreToPass** (number): This is the achievement score required to pass the assessment. The learner's score must be greater than or equal to this score. It is the cumulative raw score needed to pass unless **\_isPercentageBased** is set to `true`.    
+
+>**\_correctToPass** (number): This is the achievement correctness required to pass the assessment. The learner's correctness must be greater than or equal to this value. It is the cumulative raw correctness needed to pass unless **\_isPercentageBased** is set to `true`.    
 
 >**\_isPercentageBased** (boolean): Determines whether the value of **\_scoreToPass** should be treated as a percentage or as the raw score. For example, if **\_isPercentageBased** is set to `true`, a **\_scoreToPass** value of `60` will be treated as `60%`.   
 
@@ -145,28 +149,44 @@ A description of the stateObject returned by the assessments:events is as follow
 | isPercentageBased         | bool         | Returns a boolean signifying if the assessment scoreToPass is percentage based |
 | scoreToPass               | int          | Defines the threshold score to signify a pass |
 | score                     | int          | Returns the current score of the assessment |
-| scoreAsPercent            | int          | Returns the current score of the assessment as a percentage, (maxScore/score) * 100 |
+| scoreAsPercent            | int          | Returns the current score of the assessment as a percentage, (maxScore-minScore/score-minScore) * 100 |
 | maxScore                  | int          | Returns the maximum attainable score |
+| minScore                  | int          | Returns the minimum attainable score |
+| correctCount              | int          | Returns the current correctness of the assessment |
+| correctAsPercent          | int          | Returns the current correctness of the assessment as a percentage, (questionCount/correctCount) * 100 |
+| correctToPass             | int          | Defines the threshold correctness to signify a pass |
+| questionCount             | int          | Returns the number of questions in the assessment |
 | isPass                    | bool         | Returns a boolean signifying if the assessment is passed |
-| postScoreToLms            | bool         | Signifies that the assessment score will be posted to the LMS |
+| includeInTotalScore       | bool         | Signifies that the assessment score will be posted to the LMS |
 | assessmentWeight          | int          | Signifies the portion of the total LMS score which is derived from this assessment, (1 = 100%) |
 | attempts                  | int          | The total number of attempts specified by the configuration (0 = infinite) |
 | attemptsSpent             | int          | The total number of attempts spent by the user |
 | attemptsLeft              | int / bool   | The total number of attempts remaining for the user or true if attempts=infinite |
 | lastAttemptScoreAsPercent | int          | Returns the last attempt score |
 | questions                 | object array | Contains an array of question objects { _id: string, _isCorrect: bool, title: string, displayTitle: string } |
+| resetType                 | string       | Returns a string signifying how the questions should be reset, either 'hard' or 'soft'  |
+| allowResetIfPassed        | bool         | Returns a boolean signifying if the assessment can be reset after passing |
+| questionModels            | object       | Contains a collection of the question models |
+
 
 
 A description of the stateObject returned by the `assessment:complete` event is as follows:  
 
 | Attribute                 | Type         | Description|
 | :-------------------------|:-------------|:-----|
-| isPercentageBased         | bool         | Returns a boolean signifying if the assessment scoreToPass is percentage based |
-| scoreToPass               | int          | Defines the threshold score to signify a pass |
-| score                     | int          | Returns the current score of the assessment |
-| scoreAsPercent            | int          | Returns the current score of the assessment as a percentage, (maxScore/score) * 100 |
+| isComplete                | bool         | Returns a boolean signifying if the assessments are complete |
+| isPercentageBased         | bool         | Returns a boolean signifying if the assessments scoreToPass is percentage based |
+| isPass                    | bool         | Returns a boolean signifying if the assessments are passed |
 | maxScore                  | int          | Returns the maximum attainable score |
-| isPass                    | bool         | Returns a boolean signifying if the assessment is passed |
+| minScore                  | int          | Returns the minimum attainable score |
+| score                     | int          | Returns the current score of the assessments |
+| scoreToPass               | int          | Defines the threshold score to signify a pass |
+| scoreAsPercent            | int          | Returns the current score of the assessments as a percentage, (maxScore-minScore/score-minScore) * 100 |
+| correctCount              | int          | Returns the current correctness of the assessments |
+| correctAsPercent          | int          | Returns the current correctness of the assessments as a percentage, (questionCount/correctCount) * 100 |
+| correctToPass             | int          | Defines the threshold correctness to signify a pass |
+| questionCount             | int          | Returns the number of questions in the assessments |
+| assessmentsComplete       | int          | Returns the number of complete assessments |
 | assessments               | int          | Signifies the number of assessments passed to post back to the LMS |
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The following attributes are appended to a particular article within *articles.j
 
 >**\_correctToPass** (number): This is the achievement correctness required to pass the assessment. The learner's correctness must be greater than or equal to this value. It is the cumulative raw correctness needed to pass unless **\_isPercentageBased** is set to `true`.    
 
->**\_isPercentageBased** (boolean): Determines whether the valuex of **\_scoreToPass** and **\_correctToPass** should be treated as a percentage or as the raw score and correctness. For example, if **\_isPercentageBased** is set to `true`, a **\_scoreToPass** value of `60` will be treated as `60%`.   
+>**\_isPercentageBased** (boolean): Determines whether the values of **\_scoreToPass** and **\_correctToPass** should be treated as percentages or as the raw score and correctness. For example, if **\_isPercentageBased** is set to `true`, a **\_scoreToPass** value of `60` will be treated as `60%`.   
 
 >**\_includeInTotalScore** (boolean): Determines if the score from this assessment should be sent to the LMS. The score sent is a percentage according to **\_assessmentWeight.**   
 

--- a/example.json
+++ b/example.json
@@ -1,6 +1,7 @@
     // course.json
     "_assessment": {
-        "_scoreToPass": 75,
+        "_scoreToPass": 60,
+        "_correctToPass": 60,
         "_isPercentageBased": true
     }
 
@@ -9,7 +10,8 @@
         "_isEnabled": true,
         "_id": "Assessment 1",
         "_suppressMarking": false,
-        "_scoreToPass" : 75,
+        "_scoreToPass" : 60,
+        "_correctToPass": 60,
         "_isPercentageBased" : true,
         "_includeInTotalScore": true,
         "_assessmentWeight": 1,

--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -379,8 +379,8 @@ define([
       const correctAsPercent = this.get('_correctAsPercent');
       const correctCount = this.get('_correctCount');
 
-      const isPass = isPercentageBased 
-        ? (scoreAsPercent >= scoreToPass && correctAsPercent >= correctToPass) 
+      const isPass = isPercentageBased
+        ? (scoreAsPercent >= scoreToPass && correctAsPercent >= correctToPass)
         : (score >= scoreToPass && correctCount >= correctToPass);
 
       this.set('_isPass', isPass);

--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -744,7 +744,6 @@ define([
           });
         });
       });
-      this.set('_questions', questions);
 
       this.set({
         _isAssessmentComplete: isComplete,
@@ -758,6 +757,7 @@ define([
         _scoreAsPercent: scoreAsPercent,
         _correctAsPercent: correctAsPercent || 0,
         _correctCount: correctCount || 0,
+        _questions: questions,
         _questionCount: questionCount || 0,
         _lastAttemptScoreAsPercent: scoreAsPercent
       });
@@ -788,6 +788,7 @@ define([
         minScore: this.get('_minScore'),
         correctCount: this.get('_correctCount'),
         correctAsPercent: this.get('_correctAsPercent'),
+        correctToPass: assessmentConfig._correctToPass,
         questionCount: this.get('_questionCount'),
         isPass: this.get('_isPass'),
         includeInTotalScore: assessmentConfig._includeInTotalScore,

--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -379,7 +379,9 @@ define([
       const correctAsPercent = this.get('_correctAsPercent');
       const correctCount = this.get('_correctCount');
 
-      const isPass = isPercentageBased ? (scoreAsPercent >= scoreToPass && correctAsPercent >= correctToPass) : (score >= scoreToPass && correctCount >= correctToPass);
+      const isPass = isPercentageBased 
+        ? (scoreAsPercent >= scoreToPass && correctAsPercent >= correctToPass) 
+        : (score >= scoreToPass && correctCount >= correctToPass);
 
       this.set('_isPass', isPass);
     },

--- a/js/assessment.js
+++ b/js/assessment.js
@@ -380,7 +380,7 @@ define([
       const correctToPass = assessmentsConfig._correctToPass;
       const isPercentageBased = assessmentsConfig._isPercentageBased;
 
-      const isPass = isComplete && (isPercentageBased ?
+      const isPass = isComplete && (isPercentageBased
         ? scoreAsPercent >= scoreToPass && correctAsPercent >= correctToPass
         : score >= scoreToPass && correctCount >= correctToPass);
 

--- a/js/assessment.js
+++ b/js/assessment.js
@@ -386,15 +386,17 @@ define([
 
       return {
         isComplete: isComplete,
-        isPercentageBased: assessmentsConfig._isPercentageBased,
+        isPercentageBased: isPercentageBased,
         isPass: isPass,
-        scoreAsPercent: scoreAsPercent,
         maxScore: maxScore,
+        minScore: minScore,
         score: score,
-        scoreToPass: assessmentsConfig._scoreToPass,
+        scoreToPass: scoreToPass,
+        scoreAsPercent: scoreAsPercent,
         correctCount: correctCount,
-        questionCount: questionCount,
         correctAsPercent: correctAsPercent,
+        correctToPass: correctToPass,
+        questionCount: questionCount,
         assessmentsComplete: assessmentsComplete,
         assessments: totalAssessments
       };

--- a/js/assessment.js
+++ b/js/assessment.js
@@ -378,12 +378,11 @@ define([
 
       const scoreToPass = assessmentsConfig._scoreToPass;
       const correctToPass = assessmentsConfig._correctToPass;
+      const isPercentageBased = assessmentsConfig._isPercentageBased;
 
-      const isPass = !isComplete
-        ? false
-        : (assessmentsConfig._isPercentageBased !== false)
-          ? scoreAsPercent >= scoreToPass && correctAsPercent >= correctToPass
-          : score >= scoreToPass && correctCount >= correctToPass;
+      const isPass = isComplete && (isPercentageBased ?
+        ? scoreAsPercent >= scoreToPass && correctAsPercent >= correctToPass
+        : score >= scoreToPass && correctCount >= correctToPass);
 
       return {
         isComplete: isComplete,

--- a/properties.schema
+++ b/properties.schema
@@ -34,7 +34,7 @@
                   "title": "Pass mark",
                   "inputType": "Number",
                   "default": 60,
-                  "help": "The minimum score required by the learner to pass the assessment.",
+                  "help": "The minimum score required by the learner to pass the assessment or the minimum percentage score if 'Percentage based'.",
                   "validators": ["number"]
                 },
                 "_correctToPass": {
@@ -43,7 +43,7 @@
                   "title": "Correct pass mark",
                   "inputType": "Number",
                   "default": 60,
-                  "help": "The minimum number of correct questions required by the learner to pass the assessment.",
+                  "help": "The minimum number of correct questions required by the learner to pass the assessment or the minimum percentage correct if 'Percentage based'.",
                   "validators": ["number"]
                 }
               }

--- a/properties.schema
+++ b/properties.schema
@@ -40,7 +40,7 @@
                 "_correctToPass": {
                   "type": "number",
                   "required": false,
-                  "title": "Correct mark",
+                  "title": "Correct pass mark",
                   "inputType": "Number",
                   "default": 60,
                   "help": "The minimum number of correct questions required by the learner to pass the assessment.",

--- a/properties.schema
+++ b/properties.schema
@@ -92,7 +92,7 @@
                   "default": true,
                   "title": "Percentage based",
                   "inputType": "Checkbox",
-                  "help": "Determines whether the values of the 'Pass mark' should be treated as a percentage (default) or as the raw score and correctness.",
+                  "help": "Determines whether the pass mark values should be treated as percentages (default) or as the raw score and correctness.",
                   "validators": []
                 },
                 "_scoreToPass": {

--- a/properties.schema
+++ b/properties.schema
@@ -101,7 +101,7 @@
                   "title": "Pass mark",
                   "inputType": "Number",
                   "default": 60,
-                  "help": "The minimum score required by the learner to pass the assessment.",
+                  "help": "The minimum score required by the learner to pass the assessment or the minimum percentage score if 'Percentage based'.",
                   "validators": ["number"]
                 },
                 "_correctToPass": {
@@ -110,7 +110,7 @@
                   "title": "Correct pass mark",
                   "inputType": "Number",
                   "default": 60,
-                  "help": "The minimum number of correct questions required by the learner to pass the assessment.",
+                  "help": "The minimum number of correct questions required by the learner to pass the assessment or the minimum percentage correct if 'Percentage based'.",
                   "validators": ["number"]
                 },
                 "_includeInTotalScore": {

--- a/properties.schema
+++ b/properties.schema
@@ -107,7 +107,7 @@
                 "_correctToPass": {
                   "type": "number",
                   "required": false,
-                  "title": "Correct mark",
+                  "title": "Correct pass mark",
                   "inputType": "Number",
                   "default": 60,
                   "help": "The minimum number of correct questions required by the learner to pass the assessment.",

--- a/properties.schema
+++ b/properties.schema
@@ -25,7 +25,7 @@
                   "default": true,
                   "title": "Percentage based",
                   "inputType": "Checkbox",
-                  "help": "Determines whether the value of 'Pass mark' should be treated as a percentage (default) or as the raw score.",
+                  "help": "Determines whether the values of the 'Pass mark' should be treated as a percentage (default) or as the raw score and correctness.",
                   "validators": []
                 },
                 "_scoreToPass": {
@@ -92,7 +92,7 @@
                   "default": true,
                   "title": "Percentage based",
                   "inputType": "Checkbox",
-                  "help": "Determines whether the value of 'Pass mark' should be treated as a percentage (default) or as the raw score.",
+                  "help": "Determines whether the values of the 'Pass mark' should be treated as a percentage (default) or as the raw score and correctness.",
                   "validators": []
                 },
                 "_scoreToPass": {

--- a/properties.schema
+++ b/properties.schema
@@ -36,6 +36,15 @@
                   "default": 60,
                   "help": "The minimum score required by the learner to pass the assessment.",
                   "validators": ["number"]
+                },
+                "_correctToPass": {
+                  "type": "number",
+                  "required": false,
+                  "title": "Correct mark",
+                  "inputType": "Number",
+                  "default": 60,
+                  "help": "The minimum number of correct questions required by the learner to pass the assessment.",
+                  "validators": ["number"]
                 }
               }
             }
@@ -93,6 +102,15 @@
                   "inputType": "Number",
                   "default": 60,
                   "help": "The minimum score required by the learner to pass the assessment.",
+                  "validators": ["number"]
+                },
+                "_correctToPass": {
+                  "type": "number",
+                  "required": false,
+                  "title": "Correct mark",
+                  "inputType": "Number",
+                  "default": 60,
+                  "help": "The minimum number of correct questions required by the learner to pass the assessment.",
                   "validators": ["number"]
                 },
                 "_includeInTotalScore": {


### PR DESCRIPTION
https://github.com/adaptlearning/adapt_framework/issues/3163

### Added
* Added `correctToPass` to compliment `scoreToPass`

### Changed
* Use `QuestionModel.score`, `QuestionModel.maxScore` and `QuestionModel.minScore` rather than `_questionWeight` and `_isCorrect`

Requires https://github.com/adaptlearning/adapt_framework/pull/3172