### PR TITLE
issue/135 Fix for missing _correctToPass in course.json

### DIFF
--- a/js/assessment.js
+++ b/js/assessment.js
@@ -376,8 +376,12 @@ define([
       const scoreAsPercent = (scoreRange === 0) ? 0 : Math.round(((score - minScore) / scoreRange) * 100);
       const correctAsPercent = (questionCount === 0) ? 0 : Math.round((correctCount / questionCount) * 100);
 
+      if (assessmentsConfig._correctToPass === undefined) {
+        Adapt.log.warn('Assessment course config is missing _correctToPass');
+      }
+
       const scoreToPass = assessmentsConfig._scoreToPass;
-      const correctToPass = assessmentsConfig._correctToPass;
+      const correctToPass = assessmentsConfig._correctToPass ?? scoreToPass;
       const isPercentageBased = assessmentsConfig._isPercentageBased;
 
       const isPass = isComplete && (isPercentageBased

--- a/js/assessment.js
+++ b/js/assessment.js
@@ -377,7 +377,7 @@ define([
       const correctAsPercent = (questionCount === 0) ? 0 : Math.round((correctCount / questionCount) * 100);
 
       if (assessmentsConfig._correctToPass === undefined) {
-        Adapt.log.warn('Assessment course config is missing _correctToPass');
+        Adapt.log.warnOnce('Assessment course config is missing _correctToPass');
       }
 
       const scoreToPass = assessmentsConfig._scoreToPass;


### PR DESCRIPTION
fixes #135

### Changed
* `_correctToPass` defaults to `_scoreToPass` if undefined on the major assessment

### Added
* console warn to say that the assessment is missing `_correctToPass` in the course.json