### PR TITLE
issue/2173 Fix _isResetOnRevisit to restore failed attempts if false

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The following attributes are appended to a particular article within *articles.j
 
 >**\_isResetOnRevisit** (boolean): Controls whether the assessment should be reset automatically (up to the number of available attempts) when a user revisits the page. Acceptable values are `true` or `false`.   
 
->**\_attempts** (number): Controls the number of attempts available to the user. Any of the following values may be used to indicate an infinite number of attempts: `-1`, `0`, `null`, `undefined`, `"infinite"`. Note: If set to `"infinite"` and used in conjunction with [`_completionCriteria._requireAssessmentCompleted = true`](https://github.com/adaptlearning/adapt-contrib-core/blob/master/schema/config.model.schema#L36-L43) the course will not be considered complete until the assessment is passed.
+>**\_attempts** (number): Controls the number of attempts available to the user. Any of the following values may be used to indicate an infinite number of attempts: `-1`, `0`, `null`, `undefined`, `"infinite"`. Note: If set to `"infinite"` and used in conjunction with [`_completionCriteria._requireAssessmentCompleted = true`](https://github.com/adaptlearning/adapt-contrib-core/blob/0b0a9a6ee95aef5c54b964a3955285c705d88a5d/schema/config.model.schema#L36-L43) the course will not be considered complete until the assessment is passed.
 
 >**\_allowResetIfPassed** (boolean): Controls whether the assessment may be reset after it has been passed (whilst there are attempts remaining). Acceptable values are `true` or `false`.  
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The following attributes are appended to a particular article within *articles.j
 
 >**\_isResetOnRevisit** (boolean): Controls whether the assessment should be reset automatically (up to the number of available attempts) when a user revisits the page. Acceptable values are `true` or `false`.   
 
->**\_attempts** (number): Controls the number of attempts available to the user. Any of the following values may be used to indicate an infinite number of attempts: `-1`, `0`, `null`, `undefined`, `"infinite"`.  
+>**\_attempts** (number): Controls the number of attempts available to the user. Any of the following values may be used to indicate an infinite number of attempts: `-1`, `0`, `null`, `undefined`, `"infinite"`. Note: If set to `"infinite"` and used in conjunction with [`_completionCriteria._requireAssessmentCompleted = true`](https://github.com/adaptlearning/adapt-contrib-core/blob/master/schema/config.model.schema#L36-L43) the course will not be considered complete until the assessment is passed.
 
 >**\_allowResetIfPassed** (boolean): Controls whether the assessment may be reset after it has been passed (whilst there are attempts remaining). Acceptable values are `true` or `false`.  
 
@@ -177,6 +177,7 @@ A description of the stateObject returned by the `assessment:complete` event is 
 | isComplete                | bool         | Returns a boolean signifying if the assessments are complete |
 | isPercentageBased         | bool         | Returns a boolean signifying if the assessments scoreToPass is percentage based |
 | isPass                    | bool         | Returns a boolean signifying if the assessments are passed |
+| canRetry                  | bool         | Returns a boolean signifying if any assessment is not passed and has attempts left |
 | maxScore                  | int          | Returns the maximum attainable score |
 | minScore                  | int          | Returns the minimum attainable score |
 | score                     | int          | Returns the current score of the assessments |

--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -121,7 +121,8 @@ const AssessmentModel = {
   _setupAssessmentData(force, callback) {
     const assessmentConfig = this.getConfig();
     const state = this.getState();
-    const shouldResetAssessment = (!this.get('_attemptInProgress') && !state.isPass) || force === true;
+    const hasAttemptsLeft = (state.attemptsLeft > 0 || state.attemptsLeft === 'infinite');
+    const shouldResetAssessment = (!this.get('_attemptInProgress') && !state.isPass && hasAttemptsLeft) || force === true;
     const shouldResetQuestions = (assessmentConfig._isResetOnRevisit && (state.allowResetIfPassed || !state.isPass)) || force === true;
 
     if (shouldResetAssessment || shouldResetQuestions) {

--- a/js/assessment.js
+++ b/js/assessment.js
@@ -366,6 +366,12 @@ class Assessment extends Backbone.Controller {
       ? scoreAsPercent >= scoreToPass && correctAsPercent >= correctToPass
       : score >= scoreToPass && correctCount >= correctToPass);
 
+    const canRetry = Object.values(states).some(state => {
+      const isFailed = !state.isPass;
+      const hasAttemptsLeft = (state.attemptsLeft > 0 || state.attemptsLeft === 'infinite');
+      return (isFailed && hasAttemptsLeft);
+    });
+
     return {
       isComplete,
       isPercentageBased,
@@ -380,7 +386,8 @@ class Assessment extends Backbone.Controller {
       correctToPass,
       questionCount,
       assessmentsComplete,
-      assessments
+      assessments,
+      canRetry
     };
   }
 }


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt_framework/issues/2173
fixes https://github.com/adaptlearning/adapt_framework/issues/1448

### Fixed
* Allow failed assessment restoration when `_isResetOnRevisit: false`

### Added
* Returns `canRetry` in major assessment state for use in spoor