### PR TITLE
Fix to stop assessments from being reset when exiting mid-session, if `_isResetOnRevisit`

### DIFF
--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -122,8 +122,9 @@ const AssessmentModel = {
     const assessmentConfig = this.getConfig();
     const state = this.getState();
     const hasAttemptsLeft = (state.attemptsLeft > 0 || state.attemptsLeft === 'infinite');
-    const shouldResetAssessment = (!this.get('_attemptInProgress') && !state.isPass && hasAttemptsLeft) || force === true;
-    const shouldResetQuestions = (assessmentConfig._isResetOnRevisit && (state.allowResetIfPassed || !state.isPass)) || force === true;
+    const shouldResetOnRevisit = assessmentConfig._isResetOnRevisit && !this.get('_attemptInProgress');
+    const shouldResetAssessment = (shouldResetOnRevisit && !state.isPass && hasAttemptsLeft) || force === true;
+    const shouldResetQuestions = (shouldResetOnRevisit && (state.allowResetIfPassed || !state.isPass)) || force === true;
 
     if (shouldResetAssessment || shouldResetQuestions) {
       Adapt.trigger('assessments:preReset', this.getState(), this);


### PR DESCRIPTION
https://github.com/adaptlearning/adapt-contrib-assessment/issues/155