### PR TITLE
Fix: Ignore unavailable assessments in subprogress calculation (fix #168)

### DIFF
--- a/js/assessment.js
+++ b/js/assessment.js
@@ -199,10 +199,12 @@ class Assessment extends Backbone.Controller {
 
     for (const [ id, assessments ] of Object.entries(this._assessments._byPageId)) {
 
-      const assessmentsTotal = assessments.length;
+      const availableAssessments = assessments.filter(model => model.get('_isAvailable'));
+
+      const assessmentsTotal = availableAssessments.length;
       let assessmentsPassed = 0;
 
-      for (const assessment of assessments) {
+      for (const assessment of availableAssessments) {
         const assessmentState = assessment.getState();
 
         if (assessmentState.includeInTotalScore && !assessmentState.isPass) continue;


### PR DESCRIPTION
fixes #168 

### Fix
* Use only available assessment in progress calculations