### PR TITLE
Fix: Logging instances of question bank misuse

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 * A sentence describing each fix
 
 ### Update
-* A sentence describing each udpate
+* A sentence describing each update
 
 ### New
 * A sentence describing each new feature

--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -201,10 +201,12 @@ const AssessmentModel = {
 
     this.findDescendantModels('block')
       .filter(block => block.get('_isAvailable') && block.findDescendantModels('question').length > 0)).forEach(block => {
-        const isInvalidNumber = (isNaN(block._quizBankId) || block._quizBankId < 1);
-        const isOutOfBounds = (block._quizBankId > bankSplits.length);
-        if (isInvalidNumber) logging.warn(`Bank ID ${block._quizBankId} is not a valid number`);
-        if (isOutOfBounds) logging.warn(`Bank ID ${block._quizBankId} exceeds the number of available splits (${bankSplits.length})`);
+        const quizBankId = block.get('_assessment')?._quizBankId;
+
+        const isInvalidNumber = (isNaN(quizBankId) || quizBankId < 1);
+        const isOutOfBounds = (quizBankId > bankSplits.length);
+        if (isInvalidNumber) logging.warn(`Bank ID ${quizBankId} is not a valid number`);
+        if (isOutOfBounds) logging.warn(`Bank ID ${quizBankId} exceeds the number of available splits (${bankSplits.length})`);
     });
 
     const hasBankSplitsChanged = (bankSplits.length !== this._questionBanks?.length);

--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -200,14 +200,12 @@ const AssessmentModel = {
     const bankSplits = assessmentConfig._banks._split.split(',');
 
     this.findDescendantModels('block')
+      .filter(block => block.get('_isAvailable'))
       .filter(block => block.findDescendantModels('question').length > 0)).forEach(block => {
-        if (isNaN(block._quizBankId) || block._quizBankId < 1) {
-          logging.warn(`Bank ID ${block._quizBankId} is not a valid number`);
-        }
-
-        if (block._quizBankId > bankSplits.length) {
-          logging.warn(`Bank ID ${block._quizBankId} exceeds the number of available splits (${bankSplits.length})`);
-        }
+        const isInvalidNumber = (isNaN(block._quizBankId) || block._quizBankId < 1);
+        const isOutOfBounds = (block._quizBankId > bankSplits.length);
+        if (isInvalidNumber) logging.warn(`Bank ID ${block._quizBankId} is not a valid number`);
+        if (isOutOfBounds) logging.warn(`Bank ID ${block._quizBankId} exceeds the number of available splits (${bankSplits.length})`);
     });
 
     const hasBankSplitsChanged = (bankSplits.length !== this._questionBanks?.length);

--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -200,7 +200,7 @@ const AssessmentModel = {
     const bankSplits = assessmentConfig._banks._split.split(',');
 
     this.findDescendantModels('block')
-      .filter(block => block.get('_isAvailable') && block.findDescendantModels('question').length > 0)).forEach(block => {
+      .filter(block => block.get('_isAvailable') && block.findDescendantModels('question').length > 0).forEach(block => {
         const quizBankId = block.get('_assessment')?._quizBankId;
 
         const isInvalidNumber = (isNaN(quizBankId) || quizBankId < 1);

--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -198,6 +198,18 @@ const AssessmentModel = {
   _setupBanks() {
     const assessmentConfig = this.getConfig();
     const bankSplits = assessmentConfig._banks._split.split(',');
+
+    this.findDescendantModels('block')
+      .filter(block => block.findDescendantModels('question').length > 0)).forEach(block => {
+        if (isNaN(block._quizBankId) || block._quizBankId < 1) {
+          logging.warn(`Bank ID ${block._quizBankId} is not a valid number`);
+        }
+
+        if (block._quizBankId > bankSplits.length) {
+          logging.warn(`Bank ID ${block._quizBankId} exceeds the number of available splits (${bankSplits.length})`);
+        }
+    });
+
     const hasBankSplitsChanged = (bankSplits.length !== this._questionBanks?.length);
     if (hasBankSplitsChanged) {
       // Generate new question banks if the split has changed

--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -200,8 +200,7 @@ const AssessmentModel = {
     const bankSplits = assessmentConfig._banks._split.split(',');
 
     this.findDescendantModels('block')
-      .filter(block => block.get('_isAvailable'))
-      .filter(block => block.findDescendantModels('question').length > 0)).forEach(block => {
+      .filter(block => block.get('_isAvailable') && block.findDescendantModels('question').length > 0)).forEach(block => {
         const isInvalidNumber = (isNaN(block._quizBankId) || block._quizBankId < 1);
         const isOutOfBounds = (block._quizBankId > bankSplits.length);
         if (isInvalidNumber) logging.warn(`Bank ID ${block._quizBankId} is not a valid number`);

--- a/js/adapt-assessmentQuestionBank.js
+++ b/js/adapt-assessmentQuestionBank.js
@@ -27,14 +27,17 @@ class QuestionBank {
   }
 
   getRandomQuestionBlocks() {
-    if (this._count > this.unusedQuestionBlocks.length) {
-      logging.warn(`Bank ID ${this._bankId}: Attempting to display ${this._count} question(s), but only ${this.unusedQuestionBlocks.length} available`);
+    let count = this._count;
+
+    if (count > this.unusedQuestionBlocks.length) {
+      logging.warn(`Bank ID ${this._bankId}: Attempting to display ${count} question(s), but only ${this.unusedQuestionBlocks.length} available`);
+      count = this.unusedQuestionBlocks.length;
     }
 
     const questionBlocks = [];
     let i = 0;
 
-    while (i++ < this._count) {
+    while (i++ < count) {
       const nextBlock = this.unusedQuestionBlocks.shift();
       questionBlocks.push(nextBlock);
     }

--- a/js/adapt-assessmentQuestionBank.js
+++ b/js/adapt-assessmentQuestionBank.js
@@ -27,12 +27,12 @@ class QuestionBank {
   }
 
   getRandomQuestionBlocks() {
+    if (this._count > this.unusedQuestionBlocks.length) {
+      logging.warn(`Bank ID ${this._bankId}: Attempting to display ${this._count} question(s), but only ${this.unusedQuestionBlocks.length} available`);
+    }
+
     const questionBlocks = [];
     let i = 0;
-
-    if (this._count > this.unusedQuestionBlocks.length) {
-      logging.warn(`BankID ${this._bankId}: Attempting to display ${this._count} question(s), but only ${this.unusedQuestionBlocks.length} available.`)
-    }
 
     while (i++ < this._count) {
       const nextBlock = this.unusedQuestionBlocks.shift();

--- a/js/adapt-assessmentQuestionBank.js
+++ b/js/adapt-assessmentQuestionBank.js
@@ -1,4 +1,5 @@
 import data from 'core/js/data';
+import logging from 'core/js/logging';
 
 class QuestionBank {
 
@@ -28,6 +29,11 @@ class QuestionBank {
   getRandomQuestionBlocks() {
     const questionBlocks = [];
     let i = 0;
+
+    if (this._count > this.unusedQuestionBlocks.length) {
+      logging.warn(`BankID ${this._bankId}: Attempting to display ${this._count} question(s), but only ${this.unusedQuestionBlocks.length} available.`)
+    }
+
     while (i++ < this._count) {
       const nextBlock = this.unusedQuestionBlocks.shift();
       questionBlocks.push(nextBlock);


### PR DESCRIPTION
Fixes #173 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Logging in place for when question banks are attempting to print more than available

[//]: # (List appropriate steps for testing if needed)
### Testing
1. Create a course with an assessment that uses question banks
2. Set a bank to display three but only have two blocks/components
3. Two questions should be printed
4. Console warning should be seen