### PR TITLE
Fix: Defensive sanity check of assessment data (fixes #178)

### DIFF
--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -120,6 +120,12 @@ const AssessmentModel = {
   _onDataReady() {
     // register assessment
     Adapt.assessment.register(this);
+    
+    // sanity check the data
+    const questions = this._getCurrentQuestionComponents();
+    if (this.get('_attemptInProgress') && questions.every(q => q.get('_isSubmitted'))) {
+      this.set('_attemptInProgress', false);
+    }
   },
 
   _setupAssessmentData(force, callback) {

--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -125,6 +125,7 @@ const AssessmentModel = {
     const questions = this._getCurrentQuestionComponents();
     if (this.get('_attemptInProgress') && questions.every(q => q.get('_isSubmitted'))) {
       this.set('_attemptInProgress', false);
+      logging.warn(`Assessment ${this.get('_id') _attemptInProgress corrected as all questions are submitted`);
     }
   },
 

--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -123,7 +123,7 @@ const AssessmentModel = {
     
     // sanity check the data
     const questions = this._getCurrentQuestionComponents();
-    if (this.get('_attemptInProgress') && questions.every(q => q.get('_isSubmitted'))) {
+    if (this.get('_attemptInProgress') && questions.every(q => q.get('_isSubmitted')) && this.get('_requireCompletionOf') !== Number.POSITIVE_INFINITY) {
       this.set('_attemptInProgress', false);
       logging.warn(`Assessment ${this.get('_id') _attemptInProgress corrected as all questions are submitted`);
     }


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Checks for a conflict in data to see if assessment questions are in a submitted state while the assessment is still 'In Progress'. Fixes #178 

[//]: # (List appropriate steps for testing if needed)
### Testing
You wouldn't be able to reproduce in the core assessment. For example, our Adapt course had learners with low broadband connection as well as a distributed assessment & various banks of assessments. SCORM & xAPI was also added to this project so that contributed to slightly longer load times.
1. Ensure your course is currently SCORM-enabled on an LMS.
2. Before having another attempt at an assessment, throttle your network speeds with browser devtools
3. Upon selecting 'Retry Assessment', close the course while the loading screen is present
4. Even under these circumstances, it may take several times to reproduce.