### PR TITLE
Fix: Bank blocks only, restore other children (fixes #192)

### DIFF
--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -217,7 +217,7 @@ const AssessmentModel = {
 
     this.findDescendantModels('block')
       .filter(block => block.get('_isAvailable') && block.findDescendantModels('question').length > 0).forEach(block => {
-        const quizBankId = block.get('_assessment')?._quizBankId;
+        const quizBankId = block.get('_assessment')?._quizBankID;
 
         const isInvalidNumber = (isNaN(quizBankId) || quizBankId < 1);
         const isOutOfBounds = (quizBankId > bankSplits.length);

--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -173,6 +173,10 @@ const AssessmentModel = {
     } else if (quizModels.length === 0) {
       quizModels = this.getChildren().models;
       logging.warn('assessment: Not enough unique questions to create a fresh assessment, using last selection');
+    } else {
+      // reattach any removed non-block children, trickle buttons etc
+      const outsideModels = this._originalChildModels.filter(model => model.get('_type') !== 'block')
+      quizModels = quizModels.concat(outsideModels)
     }
     this.getChildren().reset(quizModels);
     this.setupCurrentQuestionComponents();
@@ -240,7 +244,7 @@ const AssessmentModel = {
     const assessmentConfig = this.getConfig();
 
     const randomisationModel = assessmentConfig._randomisation;
-    const blockModels = this.getChildren().models;
+    const blockModels = this.findDescendantModels('block');
 
     let questionModels = _.shuffle(blockModels);
 


### PR DESCRIPTION
fixes #192 

### Fix
* Reattached any non-block children, such as trickle buttons, if they are removed in randomisation or banking
* Changed bad variable `_quizBankId` to correct `_quizBankID`