### PR TITLE
Fix: assessment restore can error if switching to structurally different language (fixes #202)

### DIFF
--- a/js/assessment.js
+++ b/js/assessment.js
@@ -140,6 +140,7 @@ class Assessment extends Backbone.Controller {
       _byAssessmentId: {}
     });
 
+    this._saveStateModel = null;
     this._restoredCount = 0;
   }
 


### PR DESCRIPTION
#202 

### Fix
* Assessment restore can error if switching to structurally different language