### PR TITLE
Fix: Added _isAssessmentComplete: false to the soft reset logic (fix #219)

### DIFF
--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -160,7 +160,8 @@ const AssessmentModel = {
         });
       } else {
         this.set({
-          _assessmentCompleteInSession: false
+          _assessmentCompleteInSession: false,
+          _isAssessmentComplete: false
         });
       }
       this.getChildren().reset(this._originalChildModels);


### PR DESCRIPTION
Added _isAssessmentComplete: false to the soft reset logic. This ensures that when a soft reset occurs after a failed attempt, the assessment is properly marked as incomplete, preventing the _checkIfQuestionsWereRestored() method from incorrectly forcing a reset on subsequent partial completions.


