### PR TITLE
Update: Allow per-question overrides for showing feedback, marking, and model answer (fixes #232)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The following attributes are appended to a particular article within *articles.j
 
 >>**\_blockCount** (number): The number of blocks to present to the learner. (Questions are presented by blocks. If one component occupies a block, it will be presented alone. If multiple components occupy a block, they will always appear together.)
 
->**\_questions** (object): Contains attributes for overriding question component behaviours. Contains values for **\_resetType**, **\_canShowFeedback**, **\_canShowMarking** and **\_canShowModelAnswer**.
+>**\_questions** (object): Contains attributes for overriding question component behaviours. Contains values for **\_resetType**, **\_canShowFeedback**, **\_canShowMarking**, **\_canShowModelAnswer** and **\_allowComponentOverrides**.
 
 >>**\_resetType** (string): Determines whether the question component will register as completed when reset. When assigned a value of `soft`, the learner may continue to interact with it, but the component's `_isComplete` attribute remains set to `true`. When assigned `hard`, `_isComplete` is set to `false`, and the learner will be forced to complete it again if it is reset. Other plug-ins, such as [Page Level  Progress](https://github.com/adaptlearning/adapt-contrib-pageLevelProgress) and [Trickle](https://github.com/adaptlearning/adapt-contrib-trickle), base their behavior on the value of a component's `_isComplete` attribute. Acceptable values are `hard` or `soft`. For 'soft', when using trickle, please set the trickle Completion Attribute to `_isInteractionComplete'.
 
@@ -101,6 +101,8 @@ The following attributes are appended to a particular article within *articles.j
 >>**\_canShowMarking** (boolean): Determines whether question components within the assessment will show the marking after the user has answered. Acceptable values are `true` or `false`.
 
 >>**\_canShowModelAnswer** (boolean): Determines whether question components within the assessment will show the [**_showCorrectAnswer** button](https://github.com/adaptlearning/adapt_framework/wiki/Core-Buttons) or not if the user answers incorrectly. Acceptable values are `true` or `false`.
+
+>>**\_allowComponentOverrides** (boolean): When set to `true`, article-level values for **\_canShowFeedback**, **\_canShowMarking**, and **\_canShowModelAnswer** are not pushed to question components - each component's own values apply instead. Defaults to `false`, which preserves legacy behaviour where article-level values always override component values.
 
 <div float align=right><a href="#top">Back to Top</a></div>
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ If data is required to be passed to a SCORM conformant LMS, the [Spoor](https://
 
 ----------------------------
 <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>
-**Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-assessment/graphs/contributors)
-**Accessibility support:** WAI AA
-**RTL support:** Yes
-**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 13+14 for macOS/iOS/iPadOS, Opera
+**Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-assessment/graphs/contributors)<br>
+**Accessibility support:** WAI AA<br>
+**RTL support:** Yes<br>
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, Safari for macOS/iOS/iPadOS, Opera<br>

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The following attributes are appended to a particular article within *articles.j
 
 >>**\_canShowModelAnswer** (boolean): Determines whether question components within the assessment will show the [**_showCorrectAnswer** button](https://github.com/adaptlearning/adapt_framework/wiki/Core-Buttons) or not if the user answers incorrectly. Acceptable values are `true` or `false`.
 
->>**\_allowComponentOverrides** (boolean): When set to `true`, article-level values for **\_canShowFeedback**, **\_canShowMarking**, and **\_canShowModelAnswer** are not pushed to question components - each component's own values apply instead. Defaults to `false`, which preserves legacy behaviour where article-level values always override component values.
+>>**\_allowComponentOverrides** (boolean): When set to `true`, article-level values for **\_canShowFeedback**, **\_canShowMarking**, and **\_canShowModelAnswer** are not pushed to question components. Each component's own values apply instead. Defaults to `false`, which preserves legacy behaviour where article-level values always override component values.
 
 <div float align=right><a href="#top">Back to Top</a></div>
 

--- a/example.json
+++ b/example.json
@@ -32,6 +32,7 @@
             "_resetIncorrectOnly": true,
             "_resetType": "hard",
             "_comment": "For 'soft', when using trickle, please set the trickle Completion Attribute to `_isInteractionComplete'.",
+            "_allowComponentOverrides": false,
             "_canShowFeedback": false,
             "_canShowMarking": false,
             "_canShowModelAnswer": false

--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -9,10 +9,7 @@ let givenIdCount = 0;
 const assessmentConfigDefaults = {
   _isEnabled: true,
   _questions: {
-    _resetType: 'soft',
-    _canShowFeedback: false,
-    _canShowMarking: false,
-    _canShowModelAnswer: false
+    _resetType: 'soft'
   },
   _suppressMarking: false,
   _isPercentageBased: true,
@@ -99,13 +96,14 @@ const AssessmentModel = {
 
   setupCurrentQuestionComponents() {
     const assessmentQuestionsConfig = this.getConfig()._questions;
-    this._getAllQuestionComponents().forEach(component => {
-      component.set({
-        _canShowFeedback: assessmentQuestionsConfig._canShowFeedback,
-        _canShowMarking: assessmentQuestionsConfig._canShowMarking,
-        _canShowModelAnswer: assessmentQuestionsConfig._canShowModelAnswer
-      });
+    const newSettings = {};
+    ['_canShowFeedback', '_canShowMarking', '_canShowModelAnswer'].forEach(key => {
+      if (Object.prototype.hasOwnProperty.call(assessmentQuestionsConfig, key)) {
+        newSettings[key] = assessmentQuestionsConfig[key];
+      }
     });
+    if (Object.keys(newSettings).length === 0) return;
+    this._getAllQuestionComponents().forEach(component => component.set(newSettings));
   },
 
   _setAssessmentOwnershipOnChildrenModels(childModels) {

--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -9,7 +9,11 @@ let givenIdCount = 0;
 const assessmentConfigDefaults = {
   _isEnabled: true,
   _questions: {
-    _resetType: 'soft'
+    _resetType: 'soft',
+    _canShowFeedback: false,
+    _canShowMarking: false,
+    _canShowModelAnswer: false,
+    _allowComponentOverrides: false
   },
   _suppressMarking: false,
   _isPercentageBased: true,
@@ -22,6 +26,8 @@ const assessmentConfigDefaults = {
   _attempts: 'infinite',
   _allowResetIfPassed: false
 };
+
+const questionDisplayProperties = ['_canShowFeedback', '_canShowMarking', '_canShowModelAnswer'];
 
 const AssessmentModel = {
 
@@ -97,7 +103,6 @@ const AssessmentModel = {
   setupCurrentQuestionComponents() {
     const assessmentQuestionsConfig = this.getConfig()._questions;
     const newSettings = {};
-    const questionDisplayProperties = ['_canShowFeedback', '_canShowMarking', '_canShowModelAnswer'];
     questionDisplayProperties.forEach(key => {
       if (Object.prototype.hasOwnProperty.call(assessmentQuestionsConfig, key)) {
         newSettings[key] = assessmentQuestionsConfig[key];
@@ -797,10 +802,16 @@ const AssessmentModel = {
   getConfig() {
     let assessmentConfig = this.get('_assessment');
 
+    let defaults = assessmentConfigDefaults;
+    if (assessmentConfig?._questions?._allowComponentOverrides === true) {
+      defaults = $.extend(true, {}, assessmentConfigDefaults);
+      questionDisplayProperties.forEach(key => delete defaults._questions[key]);
+    }
+
     if (!assessmentConfig) {
-      assessmentConfig = $.extend(true, {}, assessmentConfigDefaults);
+      assessmentConfig = $.extend(true, {}, defaults);
     } else {
-      assessmentConfig = $.extend(true, {}, assessmentConfigDefaults, assessmentConfig);
+      assessmentConfig = $.extend(true, {}, defaults, assessmentConfig);
     }
 
     if (assessmentConfig._id === undefined) {

--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -102,6 +102,7 @@ const AssessmentModel = {
 
   setupCurrentQuestionComponents() {
     const assessmentQuestionsConfig = this.getConfig()._questions;
+    if (assessmentQuestionsConfig._allowComponentOverrides) return;
     const newSettings = {};
     questionDisplayProperties.forEach(key => {
       if (Object.prototype.hasOwnProperty.call(assessmentQuestionsConfig, key)) {
@@ -272,7 +273,7 @@ const AssessmentModel = {
 
     // Add any additional setting overrides here
     const questionConfig = this.getConfig()._questions;
-    if (Object.prototype.hasOwnProperty.call(questionConfig, '_canShowFeedback')) {
+    if (!questionConfig._allowComponentOverrides && Object.prototype.hasOwnProperty.call(questionConfig, '_canShowFeedback')) {
       newSettings._canShowFeedback = questionConfig._canShowFeedback;
     }
 
@@ -408,13 +409,14 @@ const AssessmentModel = {
       };
     } else {
       const questionConfig = this.getConfig()._questions;
+      if (!questionConfig._allowComponentOverrides) {
+        if (Object.prototype.hasOwnProperty.call(questionConfig, '_canShowModelAnswer')) {
+          markingSettings._canShowModelAnswer = questionConfig._canShowModelAnswer;
+        }
 
-      if (Object.prototype.hasOwnProperty.call(questionConfig, '_canShowModelAnswer')) {
-        markingSettings._canShowModelAnswer = questionConfig._canShowModelAnswer;
-      }
-
-      if (Object.prototype.hasOwnProperty.call(questionConfig, '_canShowMarking')) {
-        markingSettings._canShowMarking = questionConfig._canShowMarking;
+        if (Object.prototype.hasOwnProperty.call(questionConfig, '_canShowMarking')) {
+          markingSettings._canShowMarking = questionConfig._canShowMarking;
+        }
       }
     }
 

--- a/js/adapt-assessmentArticleModel.js
+++ b/js/adapt-assessmentArticleModel.js
@@ -97,7 +97,8 @@ const AssessmentModel = {
   setupCurrentQuestionComponents() {
     const assessmentQuestionsConfig = this.getConfig()._questions;
     const newSettings = {};
-    ['_canShowFeedback', '_canShowMarking', '_canShowModelAnswer'].forEach(key => {
+    const questionDisplayProperties = ['_canShowFeedback', '_canShowMarking', '_canShowModelAnswer'];
+    questionDisplayProperties.forEach(key => {
       if (Object.prototype.hasOwnProperty.call(assessmentQuestionsConfig, key)) {
         newSettings[key] = assessmentQuestionsConfig[key];
       }

--- a/migrations/v5.js
+++ b/migrations/v5.js
@@ -43,3 +43,46 @@ describe('adapt-contrib-assessment - v4.4.0 > v5.2.0', async () => {
     fromPlugins: [{ name: 'adapt-contrib-assessment', version: '5.2.0' }]
   });
 });
+
+describe('adapt-contrib-assessment - v5.4.1 > @@RELEASE_VERSION', async () => {
+  let assessmentArticles;
+
+  whereFromPlugin('adapt-contrib-assessment - from v5.4.1', { name: 'adapt-contrib-assessment', version: '<@@RELEASE_VERSION' });
+
+  whereContent('adapt-contrib-assessment - where assessment', async content => {
+    assessmentArticles = content.filter(({ _type, _assessment }) => _type === 'article' && _assessment !== undefined);
+    return assessmentArticles.length;
+  });
+
+  mutateContent('adapt-contrib-assessment - add assessment._questions._allowComponentOverrides attribute', async () => {
+    assessmentArticles.forEach(assessment => {
+      _.set(assessment, '_assessment._questions._allowComponentOverrides', false);
+    });
+    return true;
+  });
+
+  checkContent('adapt-contrib-assessment - check assessment._questions._allowComponentOverrides attribute', async () => {
+    const isValid = assessmentArticles.every(assessment => _.has(assessment, '_assessment._questions._allowComponentOverrides'));
+    if (!isValid) throw new Error('adapt-contrib-assessment - _allowComponentOverrides not added to every instance of _assessment._questions');
+    return true;
+  });
+
+  updatePlugin('adapt-contrib-assessment - update to @@RELEASE_VERSION', { name: 'adapt-contrib-assessment', version: '@@RELEASE_VERSION', framework: '>=5.19.1' });
+
+  testSuccessWhere('correct version with/without article assessment', {
+    fromPlugins: [{ name: 'adapt-contrib-assessment', version: '5.4.1' }],
+    content: [
+      { _type: 'article', _id: 'c-100', _assessment: {} },
+      { _type: 'article', _id: 'c-105' }
+    ]
+  });
+
+  testStopWhere('no assessment config or articles', {
+    fromPlugins: [{ name: 'adapt-contrib-assessment', version: '5.4.1' }],
+    content: [{ _type: 'article' }]
+  });
+
+  testStopWhere('incorrect version', {
+    fromPlugins: [{ name: 'adapt-contrib-assessment', version: '@@RELEASE_VERSION' }]
+  });
+});

--- a/properties.schema
+++ b/properties.schema
@@ -244,8 +244,7 @@
                       "required": false,
                       "title": "Show Feedback",
                       "inputType": "Checkbox",
-                      "default": false,
-                      "help": "Allows the user to view feedback on their answer.",
+                      "help": "Allows the user to view feedback on their answer. If not set, defers to the question component's own setting (which defaults to true).",
                       "validators": []
                     },
                     "_canShowMarking": {
@@ -253,8 +252,7 @@
                       "required": false,
                       "title": "Show Marking",
                       "inputType": "Checkbox",
-                      "default": false,
-                      "help": "Displays ticks and crosses on question completion.",
+                      "help": "Displays ticks and crosses on question completion. If not set, defers to the question component's own setting (which defaults to true).",
                       "validators": []
                     },
                     "_canShowModelAnswer": {
@@ -262,8 +260,7 @@
                       "required": false,
                       "title": "Show Model Answer",
                       "inputType": "Checkbox",
-                      "default": false,
-                      "help": "Allows the user to view the 'model answer' should they answer the question incorrectly.",
+                      "help": "Allows the user to view the 'model answer' should they answer the question incorrectly. If not set, defers to the question component's own setting (which defaults to true).",
                       "validators": []
                     }
                   }

--- a/properties.schema
+++ b/properties.schema
@@ -244,7 +244,8 @@
                       "required": false,
                       "title": "Show Feedback",
                       "inputType": "Checkbox",
-                      "help": "Allows the user to view feedback on their answer. If not set, defers to the question component's own setting (which defaults to true).",
+                      "default": false,
+                      "help": "Allows the user to view feedback on their answer. When 'Allow per-question overrides' is enabled, this value is only applied to question components if explicitly set; otherwise the component's own setting is preserved.",
                       "validators": []
                     },
                     "_canShowMarking": {
@@ -252,7 +253,8 @@
                       "required": false,
                       "title": "Show Marking",
                       "inputType": "Checkbox",
-                      "help": "Displays ticks and crosses on question completion. If not set, defers to the question component's own setting (which defaults to true).",
+                      "default": false,
+                      "help": "Displays ticks and crosses on question completion. When 'Allow per-question overrides' is enabled, this value is only applied to question components if explicitly set; otherwise the component's own setting is preserved.",
                       "validators": []
                     },
                     "_canShowModelAnswer": {
@@ -260,7 +262,17 @@
                       "required": false,
                       "title": "Show Model Answer",
                       "inputType": "Checkbox",
-                      "help": "Allows the user to view the 'model answer' should they answer the question incorrectly. If not set, defers to the question component's own setting (which defaults to true).",
+                      "default": false,
+                      "help": "Allows the user to view the 'model answer' should they answer the question incorrectly. When 'Allow per-question overrides' is enabled, this value is only applied to question components if explicitly set; otherwise the component's own setting is preserved.",
+                      "validators": []
+                    },
+                    "_allowComponentOverrides": {
+                      "type": "boolean",
+                      "required": false,
+                      "title": "Allow per-question overrides",
+                      "inputType": "Checkbox",
+                      "default": false,
+                      "help": "When enabled, the article-level Show Feedback, Show Marking, and Show Model Answer settings are only applied to question components if explicitly set in the article config. When disabled (default), the article-level values are always applied to every question, ignoring any component-level setting.",
                       "validators": []
                     }
                   }

--- a/schema/article.schema.json
+++ b/schema/article.schema.json
@@ -147,17 +147,26 @@
                 "_canShowFeedback": {
                   "type": "boolean",
                   "title": "Enable feedback",
-                  "description": "Allows the user to view feedback on their answer. If not set, defers to the question component's own setting (which defaults to true)."
+                  "description": "Allows the user to view feedback on their answer. When `_allowComponentOverrides` is enabled, this value is only applied to question components if explicitly set; otherwise the component's own setting is preserved.",
+                  "default": false
                 },
                 "_canShowMarking": {
                   "type": "boolean",
                   "title": "Enable marking",
-                  "description": "Displays ticks and crosses on question completion. If not set, defers to the question component's own setting (which defaults to true)."
+                  "description": "Displays ticks and crosses on question completion. When `_allowComponentOverrides` is enabled, this value is only applied to question components if explicitly set; otherwise the component's own setting is preserved.",
+                  "default": false
                 },
                 "_canShowModelAnswer": {
                   "type": "boolean",
                   "title": "Enable correct answer toggle",
-                  "description": "Allows the user to view the 'model answer' should they answer the question incorrectly. If not set, defers to the question component's own setting (which defaults to true)."
+                  "description": "Allows the user to view the 'model answer' should they answer the question incorrectly. When `_allowComponentOverrides` is enabled, this value is only applied to question components if explicitly set; otherwise the component's own setting is preserved.",
+                  "default": false
+                },
+                "_allowComponentOverrides": {
+                  "type": "boolean",
+                  "title": "Allow per-question overrides",
+                  "description": "When enabled, the article-level `_canShowFeedback`, `_canShowMarking`, and `_canShowModelAnswer` settings only apply to question components if explicitly set in the article config. When disabled (default), the article-level values are always applied to every question, ignoring any component-level setting.",
+                  "default": false
                 }
               }
             }

--- a/schema/article.schema.json
+++ b/schema/article.schema.json
@@ -147,20 +147,17 @@
                 "_canShowFeedback": {
                   "type": "boolean",
                   "title": "Enable feedback",
-                  "description": "Allows the user to view feedback on their answer",
-                  "default": false
+                  "description": "Allows the user to view feedback on their answer. If not set, defers to the question component's own setting (which defaults to true)."
                 },
                 "_canShowMarking": {
                   "type": "boolean",
                   "title": "Enable marking",
-                  "description": "Displays ticks and crosses on question completion",
-                  "default": false
+                  "description": "Displays ticks and crosses on question completion. If not set, defers to the question component's own setting (which defaults to true)."
                 },
                 "_canShowModelAnswer": {
                   "type": "boolean",
                   "title": "Enable correct answer toggle",
-                  "description": "Allows the user to view the 'model answer' should they answer the question incorrectly",
-                  "default": false
+                  "description": "Allows the user to view the 'model answer' should they answer the question incorrectly. If not set, defers to the question component's own setting (which defaults to true)."
                 }
               }
             }


### PR DESCRIPTION
Fixes #232

### Update

* Add new opt-in property `_assessment._questions._allowComponentOverrides` (default `false`). When enabled, article-level values for `_canShowFeedback`, `_canShowMarking`, and `_canShowModelAnswer` are not pushed to question components - each component's own values apply. When disabled (default), legacy behavior is preserved - article-level values always overwrite component values.
* Update schemas and documentation
* Add migration scripts

### Testing

**A. Legacy behavior** (default `_allowComponentOverrides: false`):

1. Set up an assessment article with one or more question components. On a component, set `"_canShowModelAnswer": true` in `components.json`.
2. In the article's `_assessment._questions` block, omit `_canShowModelAnswer` entirely.
3. Run the course, submit an incorrect answer to exhaust attempts.
4. Confirm the Show Correct Answer button does **not** appear (article-level default `false` overrides component, matching pre-fix behavior).

**B. New opt-in behavior** (`_allowComponentOverrides: true`):

5. In the same article, set `"_allowComponentOverrides": true` in `_assessment._questions`.
6. Run the course, exhaust attempts on the component with `_canShowModelAnswer: true`.
7. Confirm the Show Correct Answer button **does** appear.
8. With `_allowComponentOverrides: true`, set `_canShowModelAnswer: false` explicitly at the article level. Confirm the Show Correct Answer button **still appears** on the component with `_canShowModelAnswer: true` - article-level values do not override component values when the flag is enabled.

**C. Authoring tool / schema:**

9. Author a new assessment article in AAT. Confirm `_allowComponentOverrides` defaults to `false` and the article behaves identically to courses authored on the previous version.

**D. Migration:**

10. Run the migration against a course authored on v5.4.1 or earlier. Confirm every assessment article gains `_assessment._questions._allowComponentOverrides: false`.

---

Posted via collaboration with Claude Code.